### PR TITLE
실행 스크립트 오류 개선

### DIFF
--- a/.deploy/runner.sh
+++ b/.deploy/runner.sh
@@ -2,15 +2,15 @@
 
 JAR_NAME="snackgame-server.jar"
 PROCESS_ID=$(pgrep -f "$JAR_NAME")
-PATH="/home/ubuntu/snackgame-server"
+APP_PATH="/home/ubuntu/snackgame-server"
 
 if [ -n "$PROCESS_ID" ]; then
-  sudo kill $PROCESS_ID
+  sudo kill -9 $PROCESS_ID
   echo "\n🐣 구동중인 애플리케이션을 종료했습니다. (pid : $PROCESS_ID)\n"
 fi
 
 echo "\n🐣 SpringBoot 애플리케이션을 실행합니다.\n"
 
-nohup java -jar $PATH/$JAR_NAME -DSpring.profiles.active=production > $PATH/spring.log &
+nohup java -jar $APP_PATH/$JAR_NAME -DSpring.profiles.active=production > $APP_PATH/spring.log &
 
 exit


### PR DESCRIPTION
```bash
PATH="/home/ubuntu/snackgame-server"
```

이렇게 하면 환경변수의 PATH가 오버라이딩 되어 sudo, java 등의 바이너리 위치를 찾을 수 없다.