### PR TITLE
실행 스크립트 오류

### DIFF
--- a/.deploy/runner.sh
+++ b/.deploy/runner.sh
@@ -11,6 +11,6 @@ fi
 
 echo "\n🐣 SpringBoot 애플리케이션을 실행합니다.\n"
 
-nohup java -jar $APP_PATH/$JAR_NAME -DSpring.profiles.active=production > $APP_PATH/spring.log &
+nohup java -jar -DSpring.profiles.active=production $APP_PATH/$JAR_NAME > $APP_PATH/spring.log &
 
 exit


### PR DESCRIPTION
AS-IS:
```console
java -jar $APP_PATH/$JAR_NAME -DSpring.profiles.active=production
```
TO-BE:
```console
java -jar -DSpring.profiles.active=production $APP_PATH/$JAR_NAME
```

`-DSpring.profiles.active=production` 은 `-jar` 바로 뒤에 넣어야 한다. 
순서가 상관있다. 왜 이렇게 만들었는지 이유는 모르겠다. 🤷

[관련 Stackoverflow 질문](https://stackoverflow.com/a/37439625)