### PR TITLE
feat: 세션에 여러개의 수를 삽입한다

### DIFF
--- a/src/main/java/com/snackgame/server/applegame/business/AppleGameService.java
+++ b/src/main/java/com/snackgame/server/applegame/business/AppleGameService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.snackgame.server.applegame.business.domain.AppleGame;
 import com.snackgame.server.applegame.business.domain.AppleGameSessionRepository;
-import com.snackgame.server.applegame.business.domain.Coordinate;
 import com.snackgame.server.applegame.business.domain.Range;
 import com.snackgame.server.applegame.business.exception.NoSuchSessionException;
 import com.snackgame.server.applegame.controller.dto.MoveRequest;
@@ -31,8 +30,9 @@ public class AppleGameService {
     public void placeMoves(Member member, Long sessionId, List<MoveRequest> moves) {
         AppleGame game = findBy(sessionId);
         game.validateOwnedBy(member);
-        Range range = new Range(toCoordinates(moves));
-        game.removeApplesIn(range);
+        for (Range range : toRanges(moves)) {
+            game.removeApplesIn(range);
+        }
     }
 
     public AppleGame resetBoard(Member member, Long sessionId) {
@@ -54,9 +54,10 @@ public class AppleGameService {
                 .orElseThrow(NoSuchSessionException::new);
     }
 
-    private List<Coordinate> toCoordinates(List<MoveRequest> moveRequests) {
+    private List<Range> toRanges(List<MoveRequest> moveRequests) {
         return moveRequests.stream()
-                .map(moveRequest -> new Coordinate(moveRequest.getY(), moveRequest.getX()))
+                .map(MoveRequest::toCoordinates)
+                .map(Range::new)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameController.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.snackgame.server.applegame.business.AppleGameService;
 import com.snackgame.server.applegame.business.domain.AppleGame;
 import com.snackgame.server.applegame.controller.dto.AppleGameResponse;
+import com.snackgame.server.applegame.controller.dto.CoordinateRequest;
 import com.snackgame.server.applegame.controller.dto.MoveRequest;
 import com.snackgame.server.member.business.domain.Member;
 

--- a/src/main/java/com/snackgame/server/applegame/controller/dto/CoordinateRequest.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/dto/CoordinateRequest.java
@@ -1,0 +1,20 @@
+package com.snackgame.server.applegame.controller.dto;
+
+import com.snackgame.server.applegame.business.domain.Coordinate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoordinateRequest {
+
+    private Integer y;
+    private Integer x;
+
+    public Coordinate toCoordinate() {
+        return new Coordinate(y, x);
+    }
+}

--- a/src/main/java/com/snackgame/server/applegame/controller/dto/MoveRequest.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/dto/MoveRequest.java
@@ -1,5 +1,10 @@
 package com.snackgame.server.applegame.controller.dto;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.snackgame.server.applegame.business.domain.Coordinate;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +14,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MoveRequest {
 
-    private Integer y;
-    private Integer x;
+    private List<CoordinateRequest> coordinates;
+
+    public List<Coordinate> toCoordinates() {
+        return coordinates.stream()
+                .map(CoordinateRequest::toCoordinate)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/test/java/com/snackgame/server/applegame/business/AppleGameServiceTest.java
+++ b/src/test/java/com/snackgame/server/applegame/business/AppleGameServiceTest.java
@@ -14,8 +14,7 @@ import com.snackgame.server.annotation.ServiceTest;
 import com.snackgame.server.applegame.business.domain.Apple;
 import com.snackgame.server.applegame.business.domain.AppleGame;
 import com.snackgame.server.applegame.business.domain.AppleGameSessionRepository;
-import com.snackgame.server.applegame.business.domain.Coordinate;
-import com.snackgame.server.applegame.business.domain.Range;
+import com.snackgame.server.applegame.controller.dto.CoordinateRequest;
 import com.snackgame.server.applegame.controller.dto.MoveRequest;
 import com.snackgame.server.applegame.fixture.TestFixture;
 import com.snackgame.server.member.business.MemberService;
@@ -48,17 +47,22 @@ class AppleGameServiceTest {
     void 게임을_조작한다() {
         Member owner = memberService.createGuest();
         AppleGame game = appleGameSessions.save(new AppleGame(TestFixture.TWO_BY_FOUR(), owner));
-        List<MoveRequest> moves = List.of(
-                new MoveRequest(0, 1),
-                new MoveRequest(0, 3),
-                new MoveRequest(1, 1),
-                new MoveRequest(1, 3)
+        List<CoordinateRequest> coordinates = List.of(
+                new CoordinateRequest(0, 1),
+                new CoordinateRequest(0, 3),
+                new CoordinateRequest(1, 1),
+                new CoordinateRequest(1, 3)
         );
+        List<CoordinateRequest> otherCoorindates = List.of(
+                new CoordinateRequest(0, 0),
+                new CoordinateRequest(1, 0)
+        );
+        List<MoveRequest> moveRequests = List.of(new MoveRequest(coordinates), new MoveRequest(otherCoorindates));
 
-        appleGameService.placeMoves(owner, game.getSessionId(), moves);
+        appleGameService.placeMoves(owner, game.getSessionId(), moveRequests);
 
         AppleGame found = appleGameService.findBy(game.getSessionId());
-        assertThat(found.getScore()).isEqualTo(4);
+        assertThat(found.getScore()).isEqualTo(6);
     }
 
     @Test


### PR DESCRIPTION
- resolves: #35 

클라이언트에서 한번에 여러 개의 수를 삽입할 수 있다.

## AS-IS
'한 수'에 해당하는 좌표들만 입력할 수 있었다.
<img width="112" alt="image" src="https://github.com/snack-game/server/assets/39221443/8774167b-1777-430c-8e37-d30e7f901e01">

## TO-BE
여러 수를 입력할 수 있게 된다.
<img width="184" alt="image" src="https://github.com/snack-game/server/assets/39221443/bb0e511a-08aa-408d-9b85-e6f09a644f31">
