### PR TITLE
feat: JWT를 쿠키에 싣는다

### DIFF
--- a/src/main/java/com/snackgame/server/auth/BearerTokenExtractor.java
+++ b/src/main/java/com/snackgame/server/auth/BearerTokenExtractor.java
@@ -1,6 +1,9 @@
 package com.snackgame.server.auth;
 
+import java.util.Arrays;
 import java.util.Objects;
+
+import javax.servlet.http.Cookie;
 
 import com.snackgame.server.auth.exception.TokenUnresolvableException;
 
@@ -16,8 +19,17 @@ public class BearerTokenExtractor {
         throw new TokenUnresolvableException();
     }
 
-    private void requireNonNull(String authorization) {
-        if (Objects.isNull(authorization)) {
+    public String extract(Cookie[] cookies) {
+        requireNonNull(cookies);
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals("token"))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(TokenUnresolvableException::new);
+    }
+
+    private void requireNonNull(Object object) {
+        if (Objects.isNull(object)) {
             throw new TokenUnresolvableException();
         }
     }

--- a/src/main/java/com/snackgame/server/auth/JwtMemberArgumentResolver.java
+++ b/src/main/java/com/snackgame/server/auth/JwtMemberArgumentResolver.java
@@ -1,7 +1,8 @@
 package com.snackgame.server.auth;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -27,8 +28,8 @@ public class JwtMemberArgumentResolver implements HandlerMethodArgumentResolver 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
             NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        String authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
-        String token = bearerTokenExtractor.extract(authorization);
+        HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+        String token = bearerTokenExtractor.extract(request.getCookies());
         jwtProvider.validate(token);
 
         String subject = jwtProvider.getSubjectFrom(token);

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({AuthorizationException.class, MemberIdNotFoundException.class})
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ExceptionResponse handleAuthenticationException(AuthorizationException exception) {
+    public ExceptionResponse handleAuthenticationException(Exception exception) {
         logger.info(exception.getMessage(), exception.getCause());
         return ExceptionResponse.withMessageOf(exception);
     }

--- a/src/main/java/com/snackgame/server/member/controller/MemberController.java
+++ b/src/main/java/com/snackgame/server/member/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.snackgame.server.member.controller;
 
 import java.util.List;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +18,6 @@ import com.snackgame.server.member.business.MemberService;
 import com.snackgame.server.member.business.domain.Member;
 import com.snackgame.server.member.controller.dto.GroupRequest;
 import com.snackgame.server.member.controller.dto.MemberDetailsResponse;
-import com.snackgame.server.member.controller.dto.MemberDetailsWithTokenResponse;
 import com.snackgame.server.member.controller.dto.MemberRequest;
 import com.snackgame.server.member.controller.dto.NameRequest;
 
@@ -32,26 +33,35 @@ public class MemberController {
 
     @Operation(summary = "일반 사용자 생성", description = "이름, 그룹으로 사용자를 생성한다")
     @PostMapping("/members")
-    public MemberDetailsWithTokenResponse addMember(@Valid @RequestBody MemberRequest memberRequest) {
+    public MemberDetailsResponse addMember(
+            @Valid @RequestBody MemberRequest memberRequest,
+            final HttpServletResponse response
+    ) {
         Member added = memberService.createWith(memberRequest.getName(), memberRequest.getGroup());
         String accessToken = jwtProvider.createTokenWith(added.getId().toString());
-        return MemberDetailsWithTokenResponse.of(added, accessToken);
+        setCookieTo(response, accessToken);
+        return MemberDetailsResponse.of(added);
     }
 
     @Operation(summary = "게스트로 사용자 생성", description = "추가정보 없이 임시 사용자를 생성한다")
     @PostMapping("/members/guest")
-    public MemberDetailsWithTokenResponse addGuest() {
+    public MemberDetailsResponse addGuest(final HttpServletResponse response) {
         Member guest = memberService.createGuest();
         String accessToken = jwtProvider.createTokenWith(guest.getId().toString());
-        return MemberDetailsWithTokenResponse.of(guest, accessToken);
+        setCookieTo(response, accessToken);
+        return MemberDetailsResponse.of(guest);
     }
 
     @Operation(summary = "사용자의 토큰 발급", description = "어떤 이름을 가진 사용자의 토큰을 발급한다")
     @PostMapping("/members/token")
-    public MemberDetailsWithTokenResponse issueToken(@RequestBody NameRequest nameRequest) {
+    public MemberDetailsResponse issueToken(
+            @RequestBody NameRequest nameRequest,
+            final HttpServletResponse response
+    ) {
         Member found = memberService.findBy(nameRequest.getName());
         String accessToken = jwtProvider.createTokenWith(found.getId().toString());
-        return MemberDetailsWithTokenResponse.of(found, accessToken);
+        setCookieTo(response, accessToken);
+        return MemberDetailsResponse.of(found);
     }
 
     @Operation(summary = "모든 이름 검색", description = "인자로 시작하는 모든 사용자 이름을 가져온다")
@@ -76,5 +86,11 @@ public class MemberController {
     @PutMapping("/members/me/name")
     public void changeName(Member member, @RequestBody NameRequest nameRequest) {
         memberService.changeNameOf(member, nameRequest.getName());
+    }
+
+    private void setCookieTo(HttpServletResponse response, String accessToken) {
+        Cookie cookie = new Cookie("token", accessToken);
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
     }
 }


### PR DESCRIPTION
JWT를 별도 응답으로 내려주는 대신 쿠키에 싣어 관리를 편하게 한다.

회원 등록 관련 API 스펙이 일부 변경된다.
## AS-IS
<img width="231" alt="image" src="https://github.com/snack-game/server/assets/39221443/202c6d60-ab3f-48db-a0d8-ac04e81337c2">

## TO-BE

<img width="270" alt="image" src="https://github.com/snack-game/server/assets/39221443/d8c8fb7d-3a01-475b-88f0-c9a6bc1fc847">