### PR TITLE
중복 이름을 방지하고, 의존성 사이클을 제거한다

### DIFF
--- a/src/main/java/com/snackgame/server/applegame/business/domain/GameSessionTransferListener.java
+++ b/src/main/java/com/snackgame/server/applegame/business/domain/GameSessionTransferListener.java
@@ -1,0 +1,27 @@
+package com.snackgame.server.applegame.business.domain;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.snackgame.server.member.business.domain.Member;
+import com.snackgame.server.member.business.domain.SocialMember;
+import com.snackgame.server.member.business.event.GameSessionTransferEvent;
+
+@Component
+public class GameSessionTransferListener {
+
+    private final AppleGameSessionRepository appleGameSessions;
+
+    public GameSessionTransferListener(AppleGameSessionRepository appleGameSessions) {
+        this.appleGameSessions = appleGameSessions;
+    }
+
+    @EventListener
+    public void transfer(GameSessionTransferEvent event) {
+        Member victim = event.getVictim();
+        SocialMember socialMember = event.getSocialMember();
+
+        appleGameSessions.transferAll(victim, socialMember);
+        victim.invalidate();
+    }
+}

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameController.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameController.java
@@ -13,6 +13,7 @@ import com.snackgame.server.applegame.business.AppleGameService;
 import com.snackgame.server.applegame.business.domain.AppleGame;
 import com.snackgame.server.applegame.controller.dto.AppleGameResponse;
 import com.snackgame.server.applegame.controller.dto.MoveRequest;
+import com.snackgame.server.auth.jwt.FromToken;
 import com.snackgame.server.member.business.domain.Member;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,27 +28,27 @@ public class AppleGameController {
 
     @Operation(summary = "게임 세션 시작", description = "1번 게임(사과게임) 세션을 시작한다")
     @PostMapping("/games/1")
-    public AppleGameResponse startGameFor(Member member) {
+    public AppleGameResponse startGameFor(@FromToken Member member) {
         AppleGame game = appleGameService.startGameOf(member);
         return AppleGameResponse.of(game);
     }
 
     @Operation(summary = "세션에 수 삽입", description = "지정한 세션에 수들을 삽입한다")
     @PutMapping("/sessions/{sessionId}/moves")
-    public void placeMovesV1(Member member, @PathVariable Long sessionId, @RequestBody List<MoveRequest> moves) {
+    public void placeMovesV1(@FromToken Member member, @PathVariable Long sessionId, @RequestBody List<MoveRequest> moves) {
         appleGameService.placeMovesV1(member, sessionId, moves);
     }
 
     @Operation(summary = "게임판 초기화", description = "지정한 세션의 게임판을 초기화한다. 황금사과와는 별도의 기능이다.")
     @DeleteMapping("/sessions/{sessionId}/board")
-    public AppleGameResponse resetBoard(Member member, @PathVariable Long sessionId) {
+    public AppleGameResponse resetBoard(@FromToken Member member, @PathVariable Long sessionId) {
         AppleGame game = appleGameService.resetBoard(member, sessionId);
         return AppleGameResponse.of(game);
     }
 
     @Operation(summary = "게임 세션 종료", description = "현재 세션의 종료를 알린다")
     @PutMapping("/sessions/{sessionId}/end")
-    public void endSession(Member member, @PathVariable Long sessionId) {
+    public void endSession(@FromToken Member member, @PathVariable Long sessionId) {
         appleGameService.endSession(member, sessionId);
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2.java
@@ -16,6 +16,7 @@ import com.snackgame.server.applegame.business.AppleGameService;
 import com.snackgame.server.applegame.business.domain.AppleGame;
 import com.snackgame.server.applegame.controller.dto.AppleGameResponseV2;
 import com.snackgame.server.applegame.controller.dto.RangeRequest;
+import com.snackgame.server.auth.jwt.FromToken;
 import com.snackgame.server.member.business.domain.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class AppleGameControllerV2 implements AppleGameControllerV2Docs {
 
     @Override
     @PostMapping("/games/1")
-    public AppleGameResponseV2 startGameFor(Member member) {
+    public AppleGameResponseV2 startGameFor(@FromToken Member member) {
         AppleGame game = appleGameService.startGameOf(member);
         return AppleGameResponseV2.of(game);
     }
@@ -37,7 +38,7 @@ public class AppleGameControllerV2 implements AppleGameControllerV2Docs {
     @Override
     @PutMapping("/sessions/{sessionId}/moves")
     public ResponseEntity<AppleGameResponseV2> placeMoves(
-            Member member,
+            @FromToken Member member,
             @PathVariable Long sessionId,
             @RequestBody List<RangeRequest> ranges
     ) {
@@ -51,14 +52,14 @@ public class AppleGameControllerV2 implements AppleGameControllerV2Docs {
 
     @Override
     @DeleteMapping("/sessions/{sessionId}/board")
-    public AppleGameResponseV2 resetBoard(Member member, @PathVariable Long sessionId) {
+    public AppleGameResponseV2 resetBoard(@FromToken Member member, @PathVariable Long sessionId) {
         AppleGame game = appleGameService.resetBoard(member, sessionId);
         return AppleGameResponseV2.of(game);
     }
 
     @Override
     @PutMapping("/sessions/{sessionId}/end")
-    public void endSession(Member member, @PathVariable Long sessionId) {
+    public void endSession(@FromToken Member member, @PathVariable Long sessionId) {
         appleGameService.endSession(member, sessionId);
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameRankingController.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameRankingController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.snackgame.server.applegame.business.AppleGameRankingService;
 import com.snackgame.server.applegame.controller.dto.RankingResponse;
+import com.snackgame.server.auth.jwt.FromToken;
 import com.snackgame.server.member.business.domain.Member;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,7 +27,7 @@ public class AppleGameRankingController {
 
     @Operation(summary = "자신의 랭킹 조회", description = "전체에서 자신의 랭킹을 조회한다. 최대 점수 기준이다.")
     @GetMapping("/rankings/all/me")
-    public RankingResponse showBestRankingOf(Member member) {
+    public RankingResponse showBestRankingOf(@FromToken Member member) {
         return appleGameRankingService.getBestRankingOf(member.getId());
     }
 }

--- a/src/main/java/com/snackgame/server/auth/jwt/FromToken.java
+++ b/src/main/java/com/snackgame/server/auth/jwt/FromToken.java
@@ -1,0 +1,12 @@
+package com.snackgame.server.auth.jwt;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface FromToken {
+
+}

--- a/src/main/java/com/snackgame/server/auth/jwt/MemberResolver.java
+++ b/src/main/java/com/snackgame/server/auth/jwt/MemberResolver.java
@@ -1,0 +1,8 @@
+package com.snackgame.server.auth.jwt;
+
+import java.util.Optional;
+
+public interface MemberResolver<T> {
+
+    Optional<T> resolve(Long memberId);
+}

--- a/src/main/java/com/snackgame/server/auth/oauth/support/SocialMemberSaver.java
+++ b/src/main/java/com/snackgame/server/auth/oauth/support/SocialMemberSaver.java
@@ -1,0 +1,8 @@
+package com.snackgame.server.auth.oauth.support;
+
+import com.snackgame.server.auth.oauth.attributes.OAuthAttributes;
+
+public interface SocialMemberSaver<T> {
+
+    T saveMemberFrom(OAuthAttributes oAuthAttributes);
+}

--- a/src/main/java/com/snackgame/server/config/OpenApiConfig.java
+++ b/src/main/java/com/snackgame/server/config/OpenApiConfig.java
@@ -7,6 +7,7 @@ import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.snackgame.server.auth.jwt.FromToken;
 import com.snackgame.server.member.business.domain.Member;
 
 import io.swagger.v3.oas.models.Components;
@@ -55,8 +56,7 @@ public class OpenApiConfig {
     public OperationCustomizer authOperationMarker() {
         return (operation, handlerMethod) -> {
             Arrays.stream(handlerMethod.getMethodParameters())
-                    .filter(it -> Member.class.isAssignableFrom(it.getParameterType())
-                                  && !it.hasParameterAnnotations())
+                    .filter(it -> it.hasParameterAnnotation(FromToken.class))
                     .findAny()
                     .ifPresent(it -> operation.addSecurityItem(JWT_SECURITY_ITEM));
             return operation;

--- a/src/main/java/com/snackgame/server/config/WebMvcConfig.java
+++ b/src/main/java/com/snackgame/server/config/WebMvcConfig.java
@@ -8,11 +8,8 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import com.snackgame.server.auth.jwt.BearerTokenExtractor;
 import com.snackgame.server.auth.jwt.JwtMemberArgumentResolver;
-import com.snackgame.server.auth.jwt.JwtProvider;
 import com.snackgame.server.auth.oauth.support.SocialMemberSavingArgumentResolver;
-import com.snackgame.server.member.business.domain.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,17 +19,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private static final String HOST_NAME = "snackga.me";
 
-    private final JwtProvider jwtProvider;
-    private final MemberRepository memberRepository;
+    private final JwtMemberArgumentResolver jwtMemberArgumentResolver;
+    private final SocialMemberSavingArgumentResolver socialMemberSavingArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new JwtMemberArgumentResolver(
-                new BearerTokenExtractor(),
-                jwtProvider,
-                memberRepository
-        ));
-        resolvers.add(new SocialMemberSavingArgumentResolver(memberRepository));
+        resolvers.add(jwtMemberArgumentResolver);
+        resolvers.add(socialMemberSavingArgumentResolver);
     }
 
     @Override

--- a/src/main/java/com/snackgame/server/member/business/domain/DistinctNaming.java
+++ b/src/main/java/com/snackgame/server/member/business/domain/DistinctNaming.java
@@ -1,0 +1,37 @@
+package com.snackgame.server.member.business.domain;
+
+import org.springframework.stereotype.Component;
+
+import com.snackgame.server.member.business.exception.DuplicateNameException;
+
+@Component
+public class DistinctNaming {
+
+    private final MemberRepository members;
+    private final GuestNameRandomizer guestNameRandomizer = new GuestNameRandomizer();
+
+    public DistinctNaming(MemberRepository members) {
+        this.members = members;
+    }
+
+    public void validate(Name name) {
+        if (members.existsByName(name)) {
+            throw new DuplicateNameException();
+        }
+    }
+
+    public Name ofGuest() {
+        Name name = guestNameRandomizer.get();
+        while (members.existsByName(name)) {
+            name = guestNameRandomizer.get();
+        }
+        return name;
+    }
+
+    public Name from(Name name) {
+        while (members.existsByName(name)) {
+            name = name.nextAvailable();
+        }
+        return name;
+    }
+}

--- a/src/main/java/com/snackgame/server/member/business/domain/GuestNameRandomizer.java
+++ b/src/main/java/com/snackgame/server/member/business/domain/GuestNameRandomizer.java
@@ -1,18 +1,13 @@
 package com.snackgame.server.member.business.domain;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
-import org.springframework.stereotype.Component;
-
-@Component
-public class AlphabetNameRandomizer implements NameRandomizer {
+public class GuestNameRandomizer {
 
     private static final String NAME_PREFIX = "게스트#";
     private static final int RANDOMIZED_LENGTH = 8;
     private static final String ALPHABET_POOL = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    private static final Random RANDOM = new Random();
 
-    @Override
     public Name get() {
         return new Name(NAME_PREFIX + getRandomizedAlphabets(RANDOMIZED_LENGTH));
     }
@@ -20,7 +15,7 @@ public class AlphabetNameRandomizer implements NameRandomizer {
     private static String getRandomizedAlphabets(int length) {
         StringBuilder randomized = new StringBuilder();
         for (int i = 0; i < length; i++) {
-            int index = RANDOM.nextInt(ALPHABET_POOL.length());
+            int index = ThreadLocalRandom.current().nextInt(ALPHABET_POOL.length());
             randomized.append(ALPHABET_POOL.charAt(index));
         }
         return randomized.toString();

--- a/src/main/java/com/snackgame/server/member/business/domain/MemberResolverImpl.java
+++ b/src/main/java/com/snackgame/server/member/business/domain/MemberResolverImpl.java
@@ -1,0 +1,22 @@
+package com.snackgame.server.member.business.domain;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.snackgame.server.auth.jwt.MemberResolver;
+
+@Component
+public class MemberResolverImpl implements MemberResolver<Member> {
+
+    private final MemberRepository members;
+
+    public MemberResolverImpl(MemberRepository members) {
+        this.members = members;
+    }
+
+    @Override
+    public Optional<Member> resolve(Long memberId) {
+        return members.findById(memberId);
+    }
+}

--- a/src/main/java/com/snackgame/server/member/business/domain/Name.java
+++ b/src/main/java/com/snackgame/server/member/business/domain/Name.java
@@ -1,6 +1,7 @@
 package com.snackgame.server.member.business.domain;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Name {
 
+    private static final Pattern NUMBERED_PATTERN = Pattern.compile(".+_\\d+");
     @Column(name = "name")
     private String string;
 
@@ -34,6 +36,23 @@ public class Name {
         if (string.length() < 2) {
             throw new NameLengthException();
         }
+    }
+
+    public Name nextAvailable() {
+        if (NUMBERED_PATTERN.matcher(string).matches()) {
+            int underscoreIndex = string.lastIndexOf('_');
+            long currentNumber = Long.parseLong(string.substring(underscoreIndex + 1));
+            return with(currentNumber + 1);
+        }
+        return with(2);
+    }
+
+    private Name with(long suffix) {
+        int underscoreIndex = string.lastIndexOf('_');
+        if (underscoreIndex > 0) {
+            return new Name(string.substring(0, underscoreIndex) + '_' + suffix);
+        }
+        return new Name(string + '_' + suffix);
     }
 
     public String getString() {

--- a/src/main/java/com/snackgame/server/member/business/domain/NameRandomizer.java
+++ b/src/main/java/com/snackgame/server/member/business/domain/NameRandomizer.java
@@ -1,5 +1,0 @@
-package com.snackgame.server.member.business.domain;
-
-public interface NameRandomizer {
-    Name get();
-}

--- a/src/main/java/com/snackgame/server/member/business/domain/SocialMember.java
+++ b/src/main/java/com/snackgame/server/member/business/domain/SocialMember.java
@@ -16,8 +16,8 @@ public class SocialMember extends Member {
     private String provider;
     private String providedId;
 
-    public SocialMember(String name, String provider, String providedId) {
-        super(new Name(name));
+    public SocialMember(Name name, String provider, String providedId) {
+        super(name);
         this.provider = provider;
         this.providedId = providedId;
     }

--- a/src/main/java/com/snackgame/server/member/business/domain/SocialMemberSaverImpl.java
+++ b/src/main/java/com/snackgame/server/member/business/domain/SocialMemberSaverImpl.java
@@ -1,0 +1,30 @@
+package com.snackgame.server.member.business.domain;
+
+import org.springframework.stereotype.Component;
+
+import com.snackgame.server.auth.oauth.attributes.OAuthAttributes;
+import com.snackgame.server.auth.oauth.support.SocialMemberSaver;
+
+@Component
+public class SocialMemberSaverImpl implements SocialMemberSaver<SocialMember> {
+
+    private final MemberRepository members;
+    private final DistinctNaming distinctNaming;
+
+    public SocialMemberSaverImpl(MemberRepository members, DistinctNaming distinctNaming) {
+        this.members = members;
+        this.distinctNaming = distinctNaming;
+    }
+
+    @Override
+    public SocialMember saveMemberFrom(OAuthAttributes attributes) {
+        SocialMember member = members.findByProviderAndProvidedId(attributes.getProvider(), attributes.getId())
+                .orElseGet(() -> new SocialMember(
+                        distinctNaming.from(new Name(attributes.getName())),
+                        attributes.getProvider(),
+                        attributes.getId()
+                ));
+        member.setAdditional(attributes.getEmail(), attributes.getNickname(), attributes.getPictureUrl());
+        return members.save(member);
+    }
+}

--- a/src/main/java/com/snackgame/server/member/business/event/GameSessionTransferEvent.java
+++ b/src/main/java/com/snackgame/server/member/business/event/GameSessionTransferEvent.java
@@ -1,0 +1,23 @@
+package com.snackgame.server.member.business.event;
+
+import com.snackgame.server.member.business.domain.Member;
+import com.snackgame.server.member.business.domain.SocialMember;
+
+public class GameSessionTransferEvent {
+
+    private final Member victim;
+    private final SocialMember socialMember;
+
+    public GameSessionTransferEvent(Member victim, SocialMember socialMember) {
+        this.victim = victim;
+        this.socialMember = socialMember;
+    }
+
+    public Member getVictim() {
+        return victim;
+    }
+
+    public SocialMember getSocialMember() {
+        return socialMember;
+    }
+}

--- a/src/main/java/com/snackgame/server/member/controller/AuthController.java
+++ b/src/main/java/com/snackgame/server/member/controller/AuthController.java
@@ -1,4 +1,4 @@
-package com.snackgame.server.auth.controller;
+package com.snackgame.server.member.controller;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -8,6 +8,7 @@ import com.snackgame.server.auth.jwt.JwtProvider;
 import com.snackgame.server.auth.oauth.support.JustAuthenticated;
 import com.snackgame.server.member.business.MemberService;
 import com.snackgame.server.member.business.domain.Member;
+import com.snackgame.server.member.business.domain.SocialMember;
 import com.snackgame.server.member.controller.dto.MemberDetailsWithTokenResponse;
 import com.snackgame.server.member.controller.dto.NameRequest;
 
@@ -43,7 +44,7 @@ public class AuthController {
                           + "로그인 시 사용했던 <b>SESSION ID를 포함</b>해야 한다."
     )
     @PostMapping("/tokens/social")
-    public MemberDetailsWithTokenResponse issueToken(@JustAuthenticated Member socialMember) {
+    public MemberDetailsWithTokenResponse issueToken(@JustAuthenticated SocialMember socialMember) {
         String token = jwtProvider.createTokenWith(socialMember.getId().toString());
         return MemberDetailsWithTokenResponse.of(socialMember, token);
     }

--- a/src/main/java/com/snackgame/server/member/controller/MemberController.java
+++ b/src/main/java/com/snackgame/server/member/controller/MemberController.java
@@ -11,9 +11,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.snackgame.server.auth.jwt.FromToken;
 import com.snackgame.server.auth.jwt.JwtProvider;
 import com.snackgame.server.auth.oauth.support.JustAuthenticated;
 import com.snackgame.server.member.business.MemberService;
+import com.snackgame.server.member.business.domain.Guest;
 import com.snackgame.server.member.business.domain.Member;
 import com.snackgame.server.member.business.domain.SocialMember;
 import com.snackgame.server.member.controller.dto.GroupRequest;
@@ -48,19 +50,19 @@ public class MemberController {
 
     @Operation(summary = "나의 정보", description = "현재 사용자의 정보를 받아온다")
     @GetMapping("/members/me")
-    public MemberDetailsResponse showDetailsOf(Member member) {
+    public MemberDetailsResponse showDetailsOf(@FromToken Member member) {
         return MemberDetailsResponse.of(member);
     }
 
     @Operation(summary = "나의 그룹 지정", description = "현재 사용자의 그룹을 지정한다")
     @PutMapping("/members/me/group")
-    public void changeGroup(Member member, @RequestBody GroupRequest groupRequest) {
+    public void changeGroup(@FromToken Member member, @RequestBody GroupRequest groupRequest) {
         memberService.changeGroupNameOf(member, groupRequest.getGroup());
     }
 
     @Operation(summary = "나의 이름 변경", description = "현재 사용자의 이름을 변경한다")
     @PutMapping("/members/me/name")
-    public void changeName(Member member, @RequestBody NameRequest nameRequest) {
+    public void changeName(@FromToken Member member, @RequestBody NameRequest nameRequest) {
         memberService.changeNameOf(member, nameRequest.getName());
     }
 
@@ -70,7 +72,10 @@ public class MemberController {
                           + "<b>직전에 소셜 로그인을 수행</b>해야 하고, 이 때 사용했던 <b>SESSION ID를 포함</b>해야 한다."
     )
     @PostMapping("/members/me/integrate")
-    public MemberDetailsWithTokenResponse integrate(Member victim, @JustAuthenticated SocialMember socialMember) {
+    public MemberDetailsWithTokenResponse integrate(
+            @FromToken Member victim,
+            @JustAuthenticated SocialMember socialMember
+    ) {
         Member integrated = memberService.integrate(victim, socialMember);
         String token = jwtProvider.createTokenWith(integrated.getId().toString());
         return MemberDetailsWithTokenResponse.of(integrated, token);

--- a/src/test/java/com/snackgame/server/member/business/MemberServiceTest.java
+++ b/src/test/java/com/snackgame/server/member/business/MemberServiceTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.snackgame.server.annotation.ServiceTest;
+import com.snackgame.server.member.business.domain.Guest;
 import com.snackgame.server.member.business.domain.Member;
 import com.snackgame.server.member.business.domain.MemberRepository;
 import com.snackgame.server.member.business.domain.Name;
-import com.snackgame.server.member.business.domain.NameRandomizer;
 import com.snackgame.server.member.business.exception.DuplicateNameException;
 import com.snackgame.server.member.business.exception.MemberNotFoundException;
 
@@ -26,23 +26,7 @@ class MemberServiceTest {
     @Autowired
     private MemberService memberService;
     @Autowired
-    private GroupService groupService;
-    @Autowired
     private MemberRepository memberRepository;
-
-    NameRandomizer fakeNameRandomizer = new NameRandomizer() {
-        private int index = 0;
-        private final String[] names = {
-                "게스트#abc",
-                "게스트#abcd"
-        };
-
-        @Override
-        public Name get() {
-            final int index = this.index++ % names.length;
-            return new Name(names[index]);
-        }
-    };
 
     @Test
     void 이름과_그룹이름으로_사용자를_생성한다() {
@@ -78,13 +62,11 @@ class MemberServiceTest {
 
     @Test
     void 임시사용자_이름이_중복이면_다시_만든다() {
-        memberService = new MemberService(memberRepository, groupService, fakeNameRandomizer, null);
-        memberService.createWith("게스트#abc");
+        Guest existing = memberRepository.save(new Guest(new Name("게스트#abc")));
 
         Member guest = memberService.createGuest();
 
-        var created = memberRepository.findById(guest.getId()).get();
-        assertThat(created.getNameAsString()).isEqualTo("게스트#abcd");
+        assertThat(guest.getNameAsString()).isNotEqualTo(existing.getNameAsString());
     }
 
     @Test

--- a/src/test/java/com/snackgame/server/member/business/domain/GuestNameRandomizerTest.java
+++ b/src/test/java/com/snackgame/server/member/business/domain/GuestNameRandomizerTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class NameRandomizerTest {
+class GuestNameRandomizerTest {
 
-    private final NameRandomizer nameRandomizer = new AlphabetNameRandomizer();
+    private final GuestNameRandomizer nameRandomizer = new GuestNameRandomizer();
 
     @Test
     void 이름앞에_접두사가_붙는다() {

--- a/src/test/java/com/snackgame/server/member/business/domain/NameTest.java
+++ b/src/test/java/com/snackgame/server/member/business/domain/NameTest.java
@@ -1,10 +1,12 @@
 package com.snackgame.server.member.business.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.snackgame.server.member.business.exception.EmptyNameException;
@@ -30,5 +32,23 @@ class NameTest {
     void 이름이_2글자_이상이면_잘_생성된다() {
         assertThatNoException()
                 .isThrownBy(() -> new Name("2자"));
+    }
+
+    @Nested
+    class 현재_이름대신_가능한_이름을_생성한다 {
+
+        @Test
+        void 숫자가_안붙은_경우_2를_붙인다() {
+            var numbered = new Name("땡칠");
+
+            assertThat(numbered.nextAvailable().getString()).isEqualTo("땡칠_2");
+        }
+
+        @Test
+        void 숫자가_이미_붙은_경우_다음_숫자를_붙인다() {
+            var numbered = new Name("땡칠_21243");
+
+            assertThat(numbered.nextAvailable().getString()).isEqualTo("땡칠_21244");
+        }
     }
 }


### PR DESCRIPTION
### 소셜 로그인 시 중복 이름을 방지한다
- resolves: #56 

소셜 로그인 시 중복 이름이 있으면 XX_2 , XX_3 과 같은 방식으로 숫자를 올려가며 해결한다.
하나의 도메인으로 만들었기 때문에 로직이 잘 보인다:

<img width="550" alt="image" src="https://github.com/snack-game/server/assets/39221443/af37b000-7e2b-49b6-a5ed-4073b27c6646">


### 의존성 사이클을 제거한다
- resolves: #54 

(패키지 의존성이 한 방향으로 흐른다)
<img width="300" alt="image" src="https://github.com/snack-game/server/assets/39221443/1d8fe6f2-22ec-4fa3-8dc7-ba30a27cccc3">

DI와 EventListener를 사용했다.
기존 auth 패키지 -> member 패키지에 접근하는 부분은 DI를 사용해 IoC 했다.
member 패키지 -> applegame 패키지에 접근하는 부분은 EventListener를 활용했다.
(잠만요.. EventListener도 IoC를 적용하는 방법 중 하나인 것 같네요?)

이제 패키지가 확실하게 분리되고 의존성이 한 방향으로 흐르게 되었으며, 작은 모듈로 분리할 수 있는 상태가 되었다.
가장 먼저 분리하고픈건 역시.. Spring Security를 활용한 부분이다.

#### AS-IS
<img width="232" alt="image" src="https://github.com/snack-game/server/assets/39221443/ad30d8ab-bd58-4f48-85d0-140c7bb50d08">

#### TO-BE
<img width="232" alt="image" src="https://github.com/snack-game/server/assets/39221443/4811febd-6d81-4ca3-8759-f13a1f3843fa">
