### PR TITLE
refactor: 인증 예외 및 예외 응답 개선

### DIFF
--- a/src/main/java/com/snackgame/server/auth/exception/AuthException.java
+++ b/src/main/java/com/snackgame/server/auth/exception/AuthException.java
@@ -2,7 +2,19 @@ package com.snackgame.server.auth.exception;
 
 public abstract class AuthException extends RuntimeException {
 
-    public AuthException(String message) {
+    public enum Action {NONE, REISSUE}
+
+    private final Action action;
+
+    public AuthException(Action action, String message) {
         super(message);
+        this.action = action;
+    }
+
+    public String getAction() {
+        if (action.equals(Action.NONE)) {
+            return null;
+        }
+        return action.name();
     }
 }

--- a/src/main/java/com/snackgame/server/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/snackgame/server/auth/exception/InvalidTokenException.java
@@ -1,8 +1,0 @@
-package com.snackgame.server.auth.exception;
-
-public class InvalidTokenException extends AuthException {
-
-    public InvalidTokenException() {
-        super("토큰이 유효하지 않습니다");
-    }
-}

--- a/src/main/java/com/snackgame/server/auth/exception/OAuthAuthenticationException.java
+++ b/src/main/java/com/snackgame/server/auth/exception/OAuthAuthenticationException.java
@@ -3,10 +3,6 @@ package com.snackgame.server.auth.exception;
 public class OAuthAuthenticationException extends AuthException {
 
     public OAuthAuthenticationException(String message) {
-        super("소셜 사용자 인증 실패: " + message);
-    }
-
-    public OAuthAuthenticationException() {
-        super("소셜 사용자 인증에 실패했습니다");
+        super(Action.NONE, "소셜 사용자 인증 실패: " + message);
     }
 }

--- a/src/main/java/com/snackgame/server/auth/exception/TokenAuthenticationException.java
+++ b/src/main/java/com/snackgame/server/auth/exception/TokenAuthenticationException.java
@@ -3,6 +3,6 @@ package com.snackgame.server.auth.exception;
 public class TokenAuthenticationException extends AuthException {
 
     public TokenAuthenticationException() {
-        super("사용자 인증에 실패했습니다");
+        super(Action.NONE, "사용자 인증에 실패했습니다");
     }
 }

--- a/src/main/java/com/snackgame/server/auth/exception/TokenExpiredException.java
+++ b/src/main/java/com/snackgame/server/auth/exception/TokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.snackgame.server.auth.exception;
+
+public class TokenExpiredException extends AuthException {
+
+    public TokenExpiredException() {
+        super(Action.REISSUE, "토큰이 만료되었습니다");
+    }
+}

--- a/src/main/java/com/snackgame/server/auth/exception/TokenInvalidException.java
+++ b/src/main/java/com/snackgame/server/auth/exception/TokenInvalidException.java
@@ -1,0 +1,8 @@
+package com.snackgame.server.auth.exception;
+
+public class TokenInvalidException extends AuthException {
+
+    public TokenInvalidException() {
+        super(Action.NONE, "토큰이 유효하지 않습니다");
+    }
+}

--- a/src/main/java/com/snackgame/server/auth/exception/TokenUnresolvableException.java
+++ b/src/main/java/com/snackgame/server/auth/exception/TokenUnresolvableException.java
@@ -1,7 +1,8 @@
 package com.snackgame.server.auth.exception;
 
 public class TokenUnresolvableException extends AuthException {
+
     public TokenUnresolvableException() {
-        super("토큰을 읽지 못했습니다");
+        super(Action.NONE, "토큰을 읽지 못했습니다");
     }
 }

--- a/src/main/java/com/snackgame/server/auth/token/util/JwtProvider.java
+++ b/src/main/java/com/snackgame/server/auth/token/util/JwtProvider.java
@@ -3,10 +3,12 @@ package com.snackgame.server.auth.token.util;
 import java.util.Date;
 import java.util.Objects;
 
-import com.snackgame.server.auth.exception.InvalidTokenException;
+import com.snackgame.server.auth.exception.TokenExpiredException;
+import com.snackgame.server.auth.exception.TokenInvalidException;
 import com.snackgame.server.auth.exception.TokenUnresolvableException;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
@@ -65,8 +67,10 @@ public class JwtProvider {
                     .getBody()
                     .getSubject();
             validateHas(subject);
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
         } catch (JwtException | IllegalArgumentException e) {
-            throw new InvalidTokenException();
+            throw new TokenInvalidException();
         }
     }
 

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -53,6 +54,14 @@ public class GlobalExceptionHandler {
         log.debug(exception.getMessage(), exception);
 
         return new ExceptionResponse("리소스를 찾지 못했습니다");
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public ExceptionResponse handleMissingRequestParameter(HttpRequestMethodNotSupportedException exception) {
+        log.debug(exception.getMessage(), exception);
+
+        return new ExceptionResponse("HTTP 메서드가 잘못되었습니다");
     }
 
     @ExceptionHandler

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -3,8 +3,6 @@ package com.snackgame.server.common.exception;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -19,80 +17,77 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import com.snackgame.server.auth.exception.AuthException;
 import com.snackgame.server.common.exception.dto.ExceptionResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ExceptionResponse handleUnhandled(Exception exception) {
-        logError(exception);
-        return ExceptionResponse.withoutMessage();
+        log.error(exception.getMessage(), exception);
+
+        return ExceptionResponse.withDefaultMessage();
     }
 
-    @ExceptionHandler(AuthException.class)
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ExceptionResponse handleAuthenticationException(Exception exception) {
-        logWarn(exception);
-        return ExceptionResponse.withMessageOf(exception);
+    public ExceptionResponse handleAuthenticationException(AuthException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        return new ExceptionResponse(exception.getMessage());
     }
 
-    @ExceptionHandler(NoHandlerFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ExceptionResponse handleNoHandlerFound(Exception exception) {
-        logDebug(exception);
-        return ExceptionResponse.of("리소스를 찾지 못했습니다");
-    }
-
-    @ExceptionHandler(BusinessException.class)
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleBusinessException(BusinessException exception) {
-        logDebug(exception);
-        return ExceptionResponse.withMessageOf(exception);
+        log.debug(exception.getMessage(), exception);
+
+        return ExceptionResponse.from(exception);
     }
 
-    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ExceptionResponse handleNoHandlerFound(NoHandlerFoundException exception) {
+        log.debug(exception.getMessage(), exception);
+
+        return new ExceptionResponse("리소스를 찾지 못했습니다");
+    }
+
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleMissingRequestParameter(MissingServletRequestParameterException exception) {
-        logDebug(exception);
-        return ExceptionResponse.of("쿼리스트링 '" + exception.getParameterName() + "'이 없거나 잘못됐습니다");
+        log.debug(exception.getMessage(), exception);
+
+        return new ExceptionResponse("쿼리스트링 '" + exception.getParameterName() + "'이 없거나 잘못됐습니다");
     }
 
-    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleHttpMessageNotReadable(HttpMessageNotReadableException exception) {
-        logDebug(exception);
-        return ExceptionResponse.of("요청 페이로드를 읽지 못했습니다");
+        log.debug(exception.getMessage(), exception);
+
+        return new ExceptionResponse("요청 페이로드를 읽지 못했습니다");
     }
 
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleHttpMessageTypeMismatch(MethodArgumentTypeMismatchException exception) {
-        logDebug(exception);
-        return ExceptionResponse.of("요청 인자가 잘못되었습니다");
+        log.debug(exception.getMessage(), exception);
+
+        return new ExceptionResponse("요청 인자가 잘못되었습니다");
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
-        logDebug(exception);
+        log.debug(exception.getMessage(), exception);
+
         List<String> exceptionMessages = exception.getFieldErrors().stream()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.toList());
 
-        return ExceptionResponse.of(exceptionMessages);
-    }
-
-    private void logWarn(Exception exception) {
-        logger.warn(exception.toString());
-    }
-
-    private void logDebug(Exception exception) {
-        logger.debug(exception.getMessage(), exception);
-    }
-
-    private void logError(Exception exception) {
-        logger.error(exception.getMessage(), exception);
+        return new ExceptionResponse(exceptionMessages);
     }
 }

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
     public ExceptionResponse handleAuthenticationException(AuthException exception) {
         log.warn(exception.getMessage(), exception);
 
-        return new ExceptionResponse(exception.getMessage());
+        return new ExceptionResponse(exception.getAction(), exception.getMessage());
     }
 
     @ExceptionHandler

--- a/src/main/java/com/snackgame/server/common/exception/dto/ExceptionResponse.java
+++ b/src/main/java/com/snackgame/server/common/exception/dto/ExceptionResponse.java
@@ -6,27 +6,34 @@ public class ExceptionResponse {
 
     private static final String DEFAULT_MESSAGE = "처리 중 예외가 발생했습니다";
 
+    private final String action;
     private final List<String> messages;
 
+    public ExceptionResponse(String message) {
+        this.action = null;
+        this.messages = List.of(message);
+    }
 
-    private ExceptionResponse(List<String> messages) {
+    public ExceptionResponse(List<String> messages) {
+        this.action = null;
         this.messages = messages;
     }
 
-    public static ExceptionResponse withoutMessage() {
-        return ExceptionResponse.of(DEFAULT_MESSAGE);
+    public ExceptionResponse(String action, String message) {
+        this.action = action;
+        this.messages = List.of(message);
     }
 
-    public static ExceptionResponse withMessageOf(Exception exception) {
-        return ExceptionResponse.of(exception.getMessage());
+    public static ExceptionResponse withDefaultMessage() {
+        return new ExceptionResponse(DEFAULT_MESSAGE);
     }
 
-    public static ExceptionResponse of(String message) {
-        return new ExceptionResponse(List.of(message));
+    public static ExceptionResponse from(Exception exception) {
+        return new ExceptionResponse(exception.getMessage());
     }
 
-    public static ExceptionResponse of(List<String> messages) {
-        return new ExceptionResponse(messages);
+    public String getAction() {
+        return action;
     }
 
     public List<String> getMessages() {


### PR DESCRIPTION
### AS-IS
<img width="232" alt="image" src="https://github.com/snack-game/server/assets/39221443/75399f7f-2659-47e6-b4a1-3d5f11f0438e">  

잘못된 토큰에 대한 구분이 없음  
조치 방법이 없음

### TO-BE
<img width="461" alt="image" src="https://github.com/snack-game/server/assets/39221443/802ee58e-1027-4a95-87af-a7b546ea3ee5">  
<img width="463" alt="image" src="https://github.com/snack-game/server/assets/39221443/3bb8d781-45de-46a0-9aec-cdbf7a13560e">  

잘못된 토큰을 두 가지로 구분 (만료, 유효하지 않음)  
조치 방법 명시 (`null`, `REISSUE`, `LOGOUT`)

- [ ] LOGOUT 액션 추가
- [ ] 예외 상황 문서화
- [ ] 프론트 예외 처리 요청(리프레시 토큰도 만료 시 로그아웃)
