### PR TITLE
feat: 로그아웃 API를 추가한다

### DIFF
--- a/src/main/java/com/snackgame/server/auth/token/TokenService.java
+++ b/src/main/java/com/snackgame/server/auth/token/TokenService.java
@@ -18,12 +18,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TokenService {
 
-    @Value("${security.jwt.token.refresh-expire-length}")
-    private long refreshTokenExpiry;
-
     private final JwtProvider accessTokenProvider;
     private final JwtProvider refreshTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    @Value("${security.jwt.token.refresh-expire-length}")
+    private long refreshTokenExpiry;
 
     @Transactional
     public TokenDto issueFor(Long memberId) {
@@ -72,5 +71,10 @@ public class TokenService {
         String newRefreshToken = issueRefreshTokenFor(Long.parseLong(subject));
         refreshTokenRepository.deleteByToken(refreshToken);
         return newRefreshToken;
+    }
+
+    @Transactional
+    public void addBlackList(String refreshToken) {
+        refreshTokenRepository.deleteByToken(refreshToken);
     }
 }

--- a/src/main/java/com/snackgame/server/auth/token/TokenService.java
+++ b/src/main/java/com/snackgame/server/auth/token/TokenService.java
@@ -17,12 +17,12 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class TokenService {
+    @Value("${security.jwt.token.refresh-expire-length}")
+    private long refreshTokenExpiry;
 
     private final JwtProvider accessTokenProvider;
     private final JwtProvider refreshTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
-    @Value("${security.jwt.token.refresh-expire-length}")
-    private long refreshTokenExpiry;
 
     @Transactional
     public TokenDto issueFor(Long memberId) {
@@ -74,7 +74,7 @@ public class TokenService {
     }
 
     @Transactional
-    public void addBlackList(String refreshToken) {
+    public void delete(String refreshToken) {
         refreshTokenRepository.deleteByToken(refreshToken);
     }
 }

--- a/src/main/java/com/snackgame/server/auth/token/TokenService.java
+++ b/src/main/java/com/snackgame/server/auth/token/TokenService.java
@@ -43,6 +43,11 @@ public class TokenService {
         );
     }
 
+    @Transactional
+    public void delete(String refreshToken) {
+        refreshTokenRepository.deleteByToken(refreshToken);
+    }
+
     private void handleExpiration(Runnable runnable) {
         try {
             runnable.run();
@@ -71,10 +76,5 @@ public class TokenService {
         String newRefreshToken = issueRefreshTokenFor(Long.parseLong(subject));
         refreshTokenRepository.deleteByToken(refreshToken);
         return newRefreshToken;
-    }
-
-    @Transactional
-    public void delete(String refreshToken) {
-        refreshTokenRepository.deleteByToken(refreshToken);
     }
 }

--- a/src/main/java/com/snackgame/server/auth/token/domain/RefreshToken.java
+++ b/src/main/java/com/snackgame/server/auth/token/domain/RefreshToken.java
@@ -1,6 +1,5 @@
 package com.snackgame.server.auth.token.domain;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -12,13 +11,12 @@ import org.hibernate.annotations.Where;
 import com.snackgame.server.common.domain.BaseEntity;
 
 @Entity
-@SQLDelete(sql = "UPDATE refresh_token SET deleted = true WHERE refresh_token_id = ?")
+@SQLDelete(sql = "UPDATE refresh_token SET deleted = true WHERE id = ?")
 @Where(clause = "deleted = false")
 public class RefreshToken extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "refresh_token_id", updatable = false)
     private Long id;
     private String token;
 

--- a/src/main/java/com/snackgame/server/auth/token/domain/RefreshToken.java
+++ b/src/main/java/com/snackgame/server/auth/token/domain/RefreshToken.java
@@ -19,14 +19,13 @@ public class RefreshToken extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String token;
+    private final boolean deleted = false;
 
-    private boolean deleted = Boolean.FALSE;
+    protected RefreshToken() {
+    }
 
     public RefreshToken(String token) {
         this.token = token;
-    }
-
-    public RefreshToken() {
     }
 
     public Long getId() {

--- a/src/main/java/com/snackgame/server/auth/token/domain/RefreshToken.java
+++ b/src/main/java/com/snackgame/server/auth/token/domain/RefreshToken.java
@@ -1,25 +1,38 @@
 package com.snackgame.server.auth.token.domain;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import com.snackgame.server.common.domain.BaseEntity;
 
 @Entity
+@SQLDelete(sql = "UPDATE refresh_token SET deleted = true WHERE refresh_token_id = ?")
+@Where(clause = "deleted = false")
 public class RefreshToken extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id", updatable = false)
     private Long id;
     private String token;
+
+    private boolean deleted = Boolean.FALSE;
 
     public RefreshToken(String token) {
         this.token = token;
     }
 
     public RefreshToken() {
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getToken() {

--- a/src/main/java/com/snackgame/server/member/controller/AuthController.java
+++ b/src/main/java/com/snackgame/server/member/controller/AuthController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -90,4 +91,22 @@ public class AuthController {
                                 .toString()
                 );
     }
+
+    @DeleteMapping("/tokens")
+    public ResponseEntity<Void> logout(@CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
+
+        tokenService.addBlackList(refreshToken);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE,
+                        ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, null)
+                                .path("/tokens/reissue")
+                                .maxAge(0)
+                                .httpOnly(true)
+                                .secure(true)
+                                .build()
+                                .toString()
+                ).build();
+    }
+
 }

--- a/src/main/java/com/snackgame/server/member/controller/AuthController.java
+++ b/src/main/java/com/snackgame/server/member/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.snackgame.server.member.controller;
 
+import java.time.Duration;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -87,13 +89,13 @@ public class AuthController {
     @DeleteMapping("/tokens/me")
     public ResponseEntity<Void> logout(@CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
 
-        tokenService.addBlackList(refreshToken);
+        tokenService.delete(refreshToken);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE,
                         ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, null)
                                 .path("/tokens/reissue")
-                                .maxAge(0)
+                                .maxAge(Duration.ZERO)
                                 .httpOnly(true)
                                 .secure(true)
                                 .build()

--- a/src/test/java/com/snackgame/server/auth/token/TokenServiceTest.java
+++ b/src/test/java/com/snackgame/server/auth/token/TokenServiceTest.java
@@ -1,0 +1,43 @@
+package com.snackgame.server.auth.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.snackgame.server.annotation.ServiceTest;
+import com.snackgame.server.auth.token.domain.RefreshToken;
+import com.snackgame.server.auth.token.domain.RefreshTokenRepository;
+import com.snackgame.server.member.MemberService;
+import com.snackgame.server.member.domain.Member;
+
+@ServiceTest
+class TokenServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private TokenService tokenService;
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    void 리프레시_토큰_저장_검증() {
+        Member created = memberService.createGuest();
+
+        String refreshToken = tokenService.issueFor(created.getId()).getRefreshToken();
+
+        assertThat(refreshTokenRepository.findAll()).map(RefreshToken::getToken).first().isEqualTo(refreshToken);
+    }
+
+    @Test
+    void 리프레시_토큰_삭제_검증() {
+        Member created = memberService.createGuest();
+        String refreshToken = tokenService.issueFor(created.getId()).getRefreshToken();
+
+        tokenService.delete(refreshToken);
+
+        assertThat(refreshTokenRepository.findAll()).isEmpty();
+    }
+
+}

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -44,6 +44,7 @@ class AuthControllerTest {
                 .statusCode(HttpStatus.OK.value())
                 .body("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"));
+
     }
 
     @Test
@@ -66,19 +67,18 @@ class AuthControllerTest {
 
     @Test
     void 로그아웃할때_리프레시_토큰을_삭제한다() throws InterruptedException {
-        Cookie refresh_cookie = RestAssured.given()
+        Cookie TokenCookie = RestAssured.given()
                 .when().post("/tokens/guest")
                 .then().extract().detailedCookie("refreshToken");
 
-        assertThat(refreshTokenRepository.findAll()).hasSize(1);
-
-        RestAssured.given().log().all()
-                .cookie(refresh_cookie)
+        Cookie deletedTokenCookie = RestAssured.given().log().all()
+                .cookie(TokenCookie)
                 .when().delete("/tokens/me")
                 .then().log().all()
-                .statusCode(HttpStatus.OK.value());
+                .statusCode(HttpStatus.OK.value())
+                .extract().detailedCookie("refreshToken");
 
-        assertThat(refreshTokenRepository.findAll()).hasSize(0);
+        assertThat(deletedTokenCookie.getMaxAge()).isZero();
 
     }
 

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -56,7 +56,7 @@ class AuthControllerTest {
 
         RestAssured.given().log().all()
                 .cookie(refreshToken)
-                .when().post("/tokens/reissue")
+                .when().patch("/tokens/me")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
@@ -74,7 +74,7 @@ class AuthControllerTest {
 
         RestAssured.given().log().all()
                 .cookie(refresh_cookie)
-                .when().delete("/tokens")
+                .when().delete("/tokens/me")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 


### PR DESCRIPTION
## AS IS

원래는 엑세스 토큰만 사용하여 엑세스 토큰을 만료시키는 방식으로 로그아웃을 진행하였다.
하지만 리프레시 토큰이 생기고 리프레시 토큰을 만료시킬 방안이 필요했다.

## TO BE

로그아웃 API를 만들어 리프레시 토큰을 삭제(Soft-Delete)하고 
쿠키에서 리프레시 토큰을 제거하고 maxAge를 0으로 초기화하여 만료시키도록 하였다.