### PR TITLE
refactor(test): 테스트와 그 기반 코드를 보완한다

### DIFF
--- a/src/main/java/com/snackgame/server/member/MemberService.java
+++ b/src/main/java/com/snackgame/server/member/MemberService.java
@@ -59,14 +59,16 @@ public class MemberService {
     }
 
     @Transactional
-    public void changeNameOf(Member member, String name) {
+    public void changeNameOf(Long memberId, String name) {
+        Member member = members.getById(memberId);
         Name otherName = new Name(name);
         distinctNaming.validate(otherName);
         member.changeNameTo(otherName);
     }
 
     @Transactional
-    public void changeGroupNameOf(Member member, String groupName) {
+    public void changeGroupNameOf(Long memberId, String groupName) {
+        Member member = members.getById(memberId);
         Group group = groupService.createIfNotExists(groupName);
         member.changeGroupTo(group);
     }

--- a/src/main/java/com/snackgame/server/member/controller/MemberController.java
+++ b/src/main/java/com/snackgame/server/member/controller/MemberController.java
@@ -56,13 +56,13 @@ public class MemberController {
     @Operation(summary = "나의 그룹 지정", description = "현재 사용자의 그룹을 지정한다")
     @PutMapping("/members/me/group")
     public void changeGroup(@Authenticated Member member, @RequestBody GroupRequest groupRequest) {
-        memberService.changeGroupNameOf(member, groupRequest.getGroup());
+        memberService.changeGroupNameOf(member.getId(), groupRequest.getGroup());
     }
 
     @Operation(summary = "나의 이름 변경", description = "현재 사용자의 이름을 변경한다")
     @PutMapping("/members/me/name")
     public void changeName(@Authenticated Member member, @RequestBody NameRequest nameRequest) {
-        memberService.changeNameOf(member, nameRequest.getName());
+        memberService.changeNameOf(member.getId(), nameRequest.getName());
     }
 
     @Operation(

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -2,13 +2,10 @@ spring:
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   h2:
     console:
       enabled: true
-  sql:
-    init:
-      mode: never
 security:
   jwt:
     token:

--- a/src/test/java/com/snackgame/server/applegame/AppleGameServiceTest.java
+++ b/src/test/java/com/snackgame/server/applegame/AppleGameServiceTest.java
@@ -13,9 +13,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.transaction.TestTransaction;
 
-import com.snackgame.server.annotation.ServiceTest;
+import com.snackgame.server.support.general.ServiceTest;
 import com.snackgame.server.applegame.controller.dto.CoordinateRequest;
 import com.snackgame.server.applegame.controller.dto.RangeRequest;
 import com.snackgame.server.applegame.domain.game.AppleGame;
@@ -38,7 +37,6 @@ class AppleGameServiceTest {
 
     @BeforeEach
     void setUp(@Autowired EntityManagerFactory entityManagerFactory) {
-        TestTransaction.end();
         MemberFixture.persistAllUsing(entityManagerFactory);
     }
 

--- a/src/test/java/com/snackgame/server/applegame/domain/game/AppleGamesTest.java
+++ b/src/test/java/com/snackgame/server/applegame/domain/game/AppleGamesTest.java
@@ -6,14 +6,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.EntityManager;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.transaction.TestTransaction;
@@ -24,11 +21,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snackgame.server.applegame.domain.apple.Apple;
 import com.snackgame.server.applegame.fixture.TestFixture;
+import com.snackgame.server.support.general.DatabaseCleaningDataJpaTest;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@DataJpaTest
 @EnableJpaAuditing
+@DatabaseCleaningDataJpaTest
 class AppleGamesTest {
 
     @Autowired
@@ -36,9 +34,6 @@ class AppleGamesTest {
     @Autowired
     JdbcTemplate jdbcTemplate;
     ObjectMapper objectMapper = new ObjectMapper();
-
-    @Autowired
-    EntityManager em;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/snackgame/server/auth/token/TokenServiceTest.java
+++ b/src/test/java/com/snackgame/server/auth/token/TokenServiceTest.java
@@ -2,15 +2,19 @@ package com.snackgame.server.auth.token;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.snackgame.server.annotation.ServiceTest;
 import com.snackgame.server.auth.token.domain.RefreshToken;
 import com.snackgame.server.auth.token.domain.RefreshTokenRepository;
 import com.snackgame.server.member.MemberService;
 import com.snackgame.server.member.domain.Member;
+import com.snackgame.server.support.general.ServiceTest;
 
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ServiceTest
 class TokenServiceTest {
 
@@ -39,5 +43,4 @@ class TokenServiceTest {
 
         assertThat(refreshTokenRepository.findAll()).isEmpty();
     }
-
 }

--- a/src/test/java/com/snackgame/server/member/GroupServiceTest.java
+++ b/src/test/java/com/snackgame/server/member/GroupServiceTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.snackgame.server.annotation.ServiceTest;
 import com.snackgame.server.member.domain.Group;
+import com.snackgame.server.support.general.ServiceTest;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/src/test/java/com/snackgame/server/member/MemberServiceTest.java
+++ b/src/test/java/com/snackgame/server/member/MemberServiceTest.java
@@ -10,13 +10,13 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.snackgame.server.annotation.ServiceTest;
 import com.snackgame.server.member.domain.Guest;
 import com.snackgame.server.member.domain.Member;
 import com.snackgame.server.member.domain.MemberRepository;
 import com.snackgame.server.member.domain.Name;
 import com.snackgame.server.member.exception.DuplicateNameException;
 import com.snackgame.server.member.exception.MemberNotFoundException;
+import com.snackgame.server.support.general.ServiceTest;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -81,7 +81,7 @@ class MemberServiceTest {
     @Test
     void 사용자_이름을_수정한다() {
         Member member = memberService.createWith(똥수().getNameAsString());
-        memberService.changeNameOf(member, "똥똥수");
+        memberService.changeNameOf(member.getId(), "똥똥수");
 
         var found = memberRepository.findById(member.getId()).get();
         assertThat(found.getNameAsString())
@@ -93,7 +93,7 @@ class MemberServiceTest {
         memberService.createWith(땡칠().getNameAsString());
         Member member = memberService.createWith(똥수().getNameAsString());
 
-        assertThatThrownBy(() -> memberService.changeNameOf(member, 땡칠().getNameAsString()))
+        assertThatThrownBy(() -> memberService.changeNameOf(member.getId(), 땡칠().getNameAsString()))
                 .isInstanceOf(DuplicateNameException.class)
                 .hasMessage("이미 존재하는 이름입니다");
     }
@@ -101,7 +101,7 @@ class MemberServiceTest {
     @Test
     void 그룹_이름을_수정한다() {
         Member member = memberService.createWith(똥수().getNameAsString(), 똥수().getGroup().getName());
-        memberService.changeGroupNameOf(member, "홍천고");
+        memberService.changeGroupNameOf(member.getId(), "홍천고");
 
         assertThat(memberService.getBy(member.getId()).getGroup().getName())
                 .isEqualTo("홍천고");

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -4,37 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.annotation.DirtiesContext;
 
-import com.snackgame.server.auth.token.domain.RefreshTokenRepository;
+import com.snackgame.server.support.restassured.RestAssuredTest;
 
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@RestAssuredTest
 class AuthControllerTest {
-
-    @LocalServerPort
-    private int port;
-
-    @Autowired
-    private RefreshTokenRepository refreshTokenRepository;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
 
     @Test
     void 토큰을_발급한다() {
@@ -44,7 +27,6 @@ class AuthControllerTest {
                 .statusCode(HttpStatus.OK.value())
                 .body("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"));
-
     }
 
     @Test
@@ -79,7 +61,5 @@ class AuthControllerTest {
                 .extract().detailedCookie("refreshToken");
 
         assertThat(deletedTokenCookie.getMaxAge()).isZero();
-
     }
-
 }

--- a/src/test/java/com/snackgame/server/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/snackgame/server/member/domain/MemberRepositoryTest.java
@@ -13,16 +13,14 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.annotation.DirtiesContext;
 
 import com.snackgame.server.member.exception.MemberNotFoundException;
 import com.snackgame.server.member.fixture.MemberFixture;
+import com.snackgame.server.support.general.DatabaseCleaningDataJpaTest;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-@DataJpaTest
+@DatabaseCleaningDataJpaTest
 class MemberRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
+++ b/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
@@ -62,5 +62,6 @@ public class MemberFixture {
         entityManager.persist(pushing(숭실대학교(), idIgnored(시연())));
         entityManager.persist(pushing(숭실대학교(), idIgnored(주호())));
         transaction.commit();
+        entityManager.close();
     }
 }

--- a/src/test/java/com/snackgame/server/rank/applegame/AppleGameRankingServiceTest.java
+++ b/src/test/java/com/snackgame/server/rank/applegame/AppleGameRankingServiceTest.java
@@ -16,9 +16,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.test.context.transaction.TestTransaction;
 
-import com.snackgame.server.annotation.ServiceTest;
 import com.snackgame.server.applegame.domain.Coordinate;
 import com.snackgame.server.applegame.domain.Range;
 import com.snackgame.server.applegame.domain.game.AppleGame;
@@ -29,6 +27,7 @@ import com.snackgame.server.member.MemberService;
 import com.snackgame.server.member.domain.Member;
 import com.snackgame.server.member.fixture.MemberFixture;
 import com.snackgame.server.rank.applegame.domain.BestScores;
+import com.snackgame.server.support.general.ServiceTest;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -51,7 +50,6 @@ class AppleGameRankingServiceTest {
             @Autowired EntityManagerFactory entityManagerFactory,
             @Autowired ThreadPoolTaskExecutor taskExecutor
     ) throws InterruptedException {
-        TestTransaction.end();
         MemberFixture.persistAllUsing(entityManagerFactory);
 
         appleGameRankingService.renewBestScoreWith(new GameEndEvent(

--- a/src/test/java/com/snackgame/server/rank/applegame/dao/SessionRankingDaoTest.java
+++ b/src/test/java/com/snackgame/server/rank/applegame/dao/SessionRankingDaoTest.java
@@ -15,9 +15,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 
 import com.snackgame.server.applegame.domain.Coordinate;
 import com.snackgame.server.applegame.domain.Range;
@@ -26,11 +24,11 @@ import com.snackgame.server.applegame.domain.game.AppleGames;
 import com.snackgame.server.applegame.fixture.TestFixture;
 import com.snackgame.server.member.fixture.MemberFixture;
 import com.snackgame.server.rank.applegame.dao.dto.RankingDto;
+import com.snackgame.server.support.general.DatabaseCleaningDataJpaTest;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@DataJpaTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DatabaseCleaningDataJpaTest
 class SessionRankingDaoTest {
 
     private SessionRankingDao sessionRankingDao;

--- a/src/test/java/com/snackgame/server/rank/applegame/domain/BestScoresTest.java
+++ b/src/test/java/com/snackgame/server/rank/applegame/domain/BestScoresTest.java
@@ -21,11 +21,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.annotation.DirtiesContext;
 
 import com.snackgame.server.member.fixture.MemberFixture;
+import com.snackgame.server.support.general.DatabaseCleaningDataJpaTest;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@DataJpaTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DatabaseCleaningDataJpaTest
 class BestScoresTest {
 
     @Autowired

--- a/src/test/java/com/snackgame/server/support/database/CleanDatabaseBeforeEach.java
+++ b/src/test/java/com/snackgame/server/support/database/CleanDatabaseBeforeEach.java
@@ -1,0 +1,23 @@
+package com.snackgame.server.support.database;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class CleanDatabaseBeforeEach implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        DataSource dataSource = getDataSourceFrom(context);
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        new DatabaseCleaner(jdbcTemplate).clean();
+    }
+
+    private DataSource getDataSourceFrom(ExtensionContext context) {
+        return SpringExtension.getApplicationContext(context)
+                .getBean(DataSource.class);
+    }
+}

--- a/src/test/java/com/snackgame/server/support/database/DatabaseCleaner.java
+++ b/src/test/java/com/snackgame/server/support/database/DatabaseCleaner.java
@@ -1,0 +1,30 @@
+package com.snackgame.server.support.database;
+
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class DatabaseCleaner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DatabaseCleaner(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void clean() {
+        List<String> tableNames = jdbcTemplate.queryForList(
+                "SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA=SCHEMA()",
+                String.class
+        );
+        truncate(tableNames);
+    }
+
+    private void truncate(List<String> tableNames) {
+        jdbcTemplate.update("SET FOREIGN_KEY_CHECKS=0");
+        for (String tableName : tableNames) {
+            jdbcTemplate.update("TRUNCATE TABLE " + tableName);
+        }
+        jdbcTemplate.update("SET FOREIGN_KEY_CHECKS=1");
+    }
+}

--- a/src/test/java/com/snackgame/server/support/database/DatabaseCleaning.java
+++ b/src/test/java/com/snackgame/server/support/database/DatabaseCleaning.java
@@ -1,0 +1,15 @@
+package com.snackgame.server.support.database;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(CleanDatabaseBeforeEach.class)
+public @interface DatabaseCleaning {
+
+}

--- a/src/test/java/com/snackgame/server/support/general/DatabaseCleaningDataJpaTest.java
+++ b/src/test/java/com/snackgame/server/support/general/DatabaseCleaningDataJpaTest.java
@@ -1,0 +1,20 @@
+package com.snackgame.server.support.general;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.snackgame.server.support.database.CleanDatabaseBeforeEach;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(CleanDatabaseBeforeEach.class)
+@DataJpaTest(excludeAutoConfiguration = TestDatabaseAutoConfiguration.class)
+public @interface DatabaseCleaningDataJpaTest {
+
+}

--- a/src/test/java/com/snackgame/server/support/general/ServiceTest.java
+++ b/src/test/java/com/snackgame/server/support/general/ServiceTest.java
@@ -1,20 +1,19 @@
-package com.snackgame.server.annotation;
+package com.snackgame.server.support.general;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.transaction.Transactional;
-
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+
+import com.snackgame.server.support.database.CleanDatabaseBeforeEach;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@ExtendWith(CleanDatabaseBeforeEach.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@Transactional // TODO: 서비스 통합 테스트에서 Transactional 제거
 public @interface ServiceTest {
 
 }

--- a/src/test/java/com/snackgame/server/support/restassured/RestAssuredTest.java
+++ b/src/test/java/com/snackgame/server/support/restassured/RestAssuredTest.java
@@ -1,0 +1,20 @@
+package com.snackgame.server.support.restassured;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.snackgame.server.support.database.CleanDatabaseBeforeEach;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(CleanDatabaseBeforeEach.class)
+@ExtendWith(SetupRestAssuredPort.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public @interface RestAssuredTest {
+
+}

--- a/src/test/java/com/snackgame/server/support/restassured/SetupRestAssuredPort.java
+++ b/src/test/java/com/snackgame/server/support/restassured/SetupRestAssuredPort.java
@@ -1,0 +1,30 @@
+package com.snackgame.server.support.restassured;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.restassured.RestAssured;
+
+@Component
+public class SetupRestAssuredPort implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        Integer port = getEnvironmentFrom(context).getProperty("local.server.port", Integer.class);
+        if (!Objects.isNull(port)) {
+            RestAssured.port = port;
+            return;
+        }
+        throw new IllegalArgumentException("사용중인 포트를 찾지 못했습니다");
+    }
+
+    private Environment getEnvironmentFrom(ExtensionContext context) {
+        return SpringExtension.getApplicationContext(context)
+                .getBean(Environment.class);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- resolves: #78
<!-- (위 정보는 생략 가능) -->

## 변경 사항
테스트 개선 및 앞으로 테스트 추가를 위한 기반작업을 한다.

### AS-IS
- 각종 테스트에 트랜잭션 롤백을 위한 `@Transactional` 사용
  - 테스트 메서드 자체에 트랜잭션이 적용되어 실제 환경과 다른 테스트가 진행될 가능성이 높음.
- 어플리케이션 컨텍스트 초기화 및 DB 재설정을 위해 `@DirtiesContext` 사용
  - 지금까지 `@Transactional`을 사용할 수 없는 경우에 대신 사용하였음
- 연속적으로 테스트가 진행되는 경우 트랜잭션이 닫히지 않아 기아 현상 발생
  - `MemberFixture`를 저장한 후 `EntityManager`를 닫지 않아서 발생한 문제
- RestAssured를 사용한 인수 테스트 진행 시 필요한 복잡한 설정 과정 필요

### TO-BE
- JUnit Extension `BeforeEachCallback`사용, DB Truncate 자동화
  - `@DatabaseCleaning` 어노테이션 도입
- 트랜잭션 롤백을 위해 사용하던 `@Transactional`, 어플리케이션 컨텍스트 초기화를 위해 사용하던 `@DirtiesContext` 제거
  - `@DatabaseCleaningDataJpaTest``@ServiceTest` 사용 가능
- RestAssured 테스트 설정 자동화
  - `@RestAssuredTest` 사용 가능

