### PR TITLE
chore: 프로덕션의 ddl-auto 설정을 validate로 변경

### DIFF
--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -5,7 +5,7 @@ spring:
     password: ${PRODUCTION_DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
 security:
   jwt:
     token:


### PR DESCRIPTION
## 관련 이슈
(는 아니고 관련 커멘트입니다. 열심히 작성했으니 한 번 읽어봐주세용)
- https://github.com/snack-game/server/pull/91#discussion_r1464700026

## 변경 사항
### AS-IS
- ddl-auto가 update로 설정되어 있었음
  - DDL 문제로 런타임 중 오류 발생 가능성이 있었음.
  - 어플리케이션이 사용하는 DB 계정은 어차피 권한이 없어 DDL 수정이 불가함.

### TO-BE
- ddl-auto를 validate로 설정한다
  - 어플리케이션 실행 시점에 DDL을 검증한다.
  - 문제가 있으면 배포가 취소되므로 한층 안전해졌음.