### PR TITLE
refactor: 액세스 토큰을 쿠키로 이관한다

### DIFF
--- a/src/main/java/com/snackgame/server/auth/token/TokenService.java
+++ b/src/main/java/com/snackgame/server/auth/token/TokenService.java
@@ -20,6 +20,9 @@ public class TokenService {
     @Value("${security.jwt.token.refresh-expire-length}")
     private long refreshTokenExpiry;
 
+    @Value("${security.jwt.token.access-expire-length}")
+    private long accessTokenExpiry;
+
     private final JwtProvider accessTokenProvider;
     private final JwtProvider refreshTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -29,6 +32,7 @@ public class TokenService {
         return new TokenDto(
                 issueAccessTokenFor(memberId),
                 issueRefreshTokenFor(memberId),
+                Duration.ofSeconds(accessTokenExpiry),
                 Duration.ofSeconds(refreshTokenExpiry)
         );
     }
@@ -39,6 +43,7 @@ public class TokenService {
         return new TokenDto(
                 reissueAccessTokenFrom(refreshToken),
                 reissueRefreshTokenFrom(refreshToken),
+                Duration.ofSeconds(accessTokenExpiry),
                 Duration.ofSeconds(refreshTokenExpiry)
         );
     }

--- a/src/main/java/com/snackgame/server/auth/token/dto/TokenDto.java
+++ b/src/main/java/com/snackgame/server/auth/token/dto/TokenDto.java
@@ -11,5 +11,6 @@ public class TokenDto {
 
     private final String accessToken;
     private final String refreshToken;
+    private final Duration accessTokenExpiry;
     private final Duration refreshTokenExpiry;
 }

--- a/src/main/java/com/snackgame/server/auth/token/support/JwtMemberArgumentResolver.java
+++ b/src/main/java/com/snackgame/server/auth/token/support/JwtMemberArgumentResolver.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,8 @@ public class JwtMemberArgumentResolver implements HandlerMethodArgumentResolver 
     private final JwtProvider accessTokenProvider;
     private final MemberResolver<?> memberResolver;
 
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(Authenticated.class);
@@ -40,28 +44,34 @@ public class JwtMemberArgumentResolver implements HandlerMethodArgumentResolver 
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
     ) {
+
+        Optional<Cookie> foundCookie = getCookieFromRequest(webRequest);
+        if (foundCookie.isPresent()) {
+            String cookieToken = foundCookie.get().getValue();
+
+            return resolveMember(cookieToken);
+        }
+        String authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        String headerToken = bearerTokenExtractor.extract(authorization);
+
+        return resolveMember(headerToken);
+    }
+
+    private Optional<Cookie> getCookieFromRequest(NativeWebRequest webRequest) {
         HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
-
-        Long memberId = null ;
-
-        if(request.getCookies() != null) {
-            Optional<Cookie> foundCookie = Arrays.stream(request.getCookies())
+        if (request.getCookies() != null) {
+            return Arrays.stream(request.getCookies())
                     .filter(cookie -> cookie.getName().equals("accessToken"))
                     .findFirst();
-            if(foundCookie.isPresent()){
-                String cookieToken = foundCookie.get().getValue();
-                accessTokenProvider.validate(cookieToken);
-
-                memberId = Long.parseLong(accessTokenProvider.getSubjectFrom(cookieToken));
-            }
-
-        } else {
-            String authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
-            String headerToken = bearerTokenExtractor.extract(authorization);
-            accessTokenProvider.validate(headerToken);
-
-            memberId = Long.parseLong(accessTokenProvider.getSubjectFrom(headerToken));
         }
+        log.error("요청에 쿠키가 존재하지 않습니다.");
+        return Optional.empty();
+    }
+
+    private Object resolveMember(String token) {
+        accessTokenProvider.validate(token);
+
+        Long memberId = Long.parseLong(accessTokenProvider.getSubjectFrom(token));
         return memberResolver.resolve(memberId)
                 .orElseThrow(TokenAuthenticationException::new);
     }

--- a/src/main/java/com/snackgame/server/member/controller/AuthController.java
+++ b/src/main/java/com/snackgame/server/member/controller/AuthController.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private final MemberService memberService;
@@ -91,28 +92,42 @@ public class AuthController {
 
         tokenService.delete(refreshToken);
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE,
-                        ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, null)
-                                .path("/tokens/reissue")
-                                .maxAge(Duration.ZERO)
-                                .httpOnly(true)
-                                .secure(true)
-                                .build()
-                                .toString()
-                ).build();
+        return deleteWith();
     }
 
     private ResponseEntity.BodyBuilder responseWith(TokenDto token) {
+        return responseEntityBuilder(token.getAccessToken(), token.getRefreshToken(),
+                token.getAccessTokenExpiry(), token.getRefreshTokenExpiry());
+    }
+
+    private ResponseEntity deleteWith() {
+        return responseEntityBuilder(null, null, Duration.ZERO, Duration.ZERO).build();
+    }
+
+    private ResponseEntity.BodyBuilder responseEntityBuilder(
+            String accessToken,
+            String refreshToken,
+            Duration accessAge,
+            Duration refreshAge) {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE,
-                        ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, token.getRefreshToken())
-                                .path("/tokens/reissue")
-                                .maxAge(token.getRefreshTokenExpiry())
+                        ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                                .path("/tokens/me")
+                                .maxAge(refreshAge)
                                 .httpOnly(true)
+                                .sameSite("None")
+                                .secure(true)
+                                .build()
+                                .toString(),
+                        ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
+                                .path("/")
+                                .maxAge(accessAge)
+                                .httpOnly(true)
+                                .sameSite("None")
                                 .secure(true)
                                 .build()
                                 .toString()
                 );
     }
+
 }

--- a/src/test/java/com/snackgame/server/auth/token/support/JwtMemberArgumentResolverTest.java
+++ b/src/test/java/com/snackgame/server/auth/token/support/JwtMemberArgumentResolverTest.java
@@ -1,0 +1,69 @@
+package com.snackgame.server.auth.token.support;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.snackgame.server.support.restassured.RestAssuredTest;
+
+import io.restassured.RestAssured;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@RestAssuredTest
+class JwtMemberArgumentResolverTest {
+
+    @RestController
+    static class FakeController {
+
+        public static final String AUTHORIZED_ENDPOINT = "/authorized/endpoint";
+        public static final String EXPECTED_RESPONSE = "test-pass";
+
+        @GetMapping(AUTHORIZED_ENDPOINT)
+        public String authenticatedEndpoint(@Authenticated Object object) {
+            return EXPECTED_RESPONSE;
+        }
+    }
+
+    @Nested
+    class 액세스_토큰을 {
+
+        @Test
+        void 헤더에서_읽는다() {
+            String accessToken = getValidAccessToken();
+
+            RestAssured.given()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .when().get(FakeController.AUTHORIZED_ENDPOINT)
+                    .then().log().all()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(equalTo(FakeController.EXPECTED_RESPONSE));
+        }
+
+        @Test
+        void 쿠키에서_읽는다() {
+            String accessToken = getValidAccessToken();
+
+            RestAssured.given()
+                    .cookie("accessToken", accessToken)
+                    .when().get(FakeController.AUTHORIZED_ENDPOINT)
+                    .then().log().all()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(equalTo(FakeController.EXPECTED_RESPONSE));
+        }
+
+        private String getValidAccessToken() {
+            return RestAssured.given()
+                    .when().post("/tokens/guest")
+                    .then().extract().body().path("accessToken")
+                    .toString();
+        }
+    }
+}

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -30,6 +30,14 @@ class AuthControllerTest {
     }
 
     @Test
+    void 토큰을_쿠키에_싣는다() {
+        RestAssured.given()
+                .when().post("/tokens/guest")
+                .then().log().all()
+                .cookie("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"));
+    }
+
+    @Test
     void 리프레시_토큰으로_토큰을_재발급한다() throws InterruptedException {
         Cookie refreshToken = RestAssured.given()
                 .when().post("/tokens/guest")

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -1,10 +1,12 @@
 package com.snackgame.server.member.controller;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -14,6 +16,7 @@ import com.snackgame.server.support.restassured.RestAssuredTest;
 
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
+import io.restassured.http.Cookies;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -22,13 +25,18 @@ class AuthControllerTest {
 
     @Test
     void 토큰을_발급한다() {
-        RestAssured.given().log().all()
+        Cookies cookies = RestAssured.given().log().all()
                 .when().post("/tokens/guest")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
-                .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"));
+                .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
+                .extract().detailedCookies();
+
+        assertThat(cookies.get("accessToken").getSameSite()).isEqualTo("None");
+        assertThat(cookies.get("refreshToken").getSameSite()).isEqualTo("None");
+
     }
 
     @Test

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -27,6 +27,7 @@ class AuthControllerTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
+                .cookie("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"));
     }
 
@@ -35,7 +36,8 @@ class AuthControllerTest {
         RestAssured.given()
                 .when().post("/tokens/guest")
                 .then().log().all()
-                .cookie("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"));
+                .cookie("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
+                .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"));
     }
 
     @Test
@@ -52,6 +54,7 @@ class AuthControllerTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
+                .cookie("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("refreshToken", not(refreshToken.getValue()));
     }

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.snackgame.server.member.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -56,18 +57,17 @@ class AuthControllerTest {
     }
 
     @Test
-    void 로그아웃할때_리프레시_토큰을_삭제한다() throws InterruptedException {
-        Cookie TokenCookie = RestAssured.given()
+    void 로그아웃할때_토큰을_삭제한다() {
+        var cookies = RestAssured.given()
                 .when().post("/tokens/guest")
-                .then().extract().detailedCookie("refreshToken");
+                .then().extract().detailedCookies();
 
-        Cookie deletedTokenCookie = RestAssured.given().log().all()
-                .cookie(TokenCookie)
+        RestAssured.given().log().all()
+                .cookies(cookies)
                 .when().delete("/tokens/me")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .extract().detailedCookie("refreshToken");
-
-        assertThat(deletedTokenCookie.getMaxAge()).isZero();
+                .cookie("accessToken", is(emptyString()))
+                .cookie("refreshToken", is(emptyString()));
     }
 }


### PR DESCRIPTION
[노션 페이지](https://jumbled-droplet-70f.notion.site/49fde1b1292048b09d755c6629a1b6e8?pvs=4)에 제가 고민한 내용들을 먼저 적어두었는데, 정환님도 함께 고민해보고 글을 완성시켜주셨으면 좋겠어요!

특히 다음 측면을 고려하면서 진행해보면 성장이 있을 것 같습니다 🚀:
- '서버 배포와 클라이언트 배포의 시간적 순서'
- '어떻게 클라이언트 개발자들이 대응할 때까지 시간을 벌어줄 수 있을까?' 

## 변경 사항
### AS-IS
토큰을 Response Body에 싣어 응답하고, 클라이언트에서 직접 관리하였다.

### TO-BE
과도기: 토큰을 Response Body와 쿠키 모두에 싣어 응답한다.

클라이언트 배포 이후: 모든 토큰을 완전히 쿠키로 이관한다.