### PR TITLE
fix: 토큰 기간 연장 및 관련 문서화 작업

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,10 +59,10 @@ jobs:
         run: |
           nohup java -javaagent:dd-java-agent.jar \
           -Dspring.profiles.active=production \
-          -DJWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }} \
-          -DJWT_EXPIRE_LENGTH=${{ secrets.JWT_EXPIRE_LENGTH }} \
-          -DJWT_REFRESH_SECRET_KEY=${{ secrets.JWT_REFRESH_SECRET_KEY }} \
-          -DJWT_REFRESH_EXPIRE_LENGTH=${{ secrets.JWT_REFRESH_EXPIRE_LENGTH }} \
+          -DACCESS_TOKEN_SECRET_KEY=${{ secrets.ACCESS_TOKEN_SECRET_KEY }} \
+          -DACCESS_TOKEN_EXPIRY_DAYS=${{ secrets.ACCESS_TOKEN_EXPIRY_DAYS }} \
+          -DREFRESH_TOKEN_SECRET_KEY=${{ secrets.REFRESH_TOKEN_SECRET_KEY }} \
+          -DREFRESH_TOKEN_EXPIRY_DAYS=${{ secrets.REFRESH_TOKEN_EXPIRY_DAYS }} \
           -Dserver.port=$GREEN_PORT \
           -DPRODUCTION_DB_URL=${{ secrets.PRODUCTION_DB_URL }} \
           -DPRODUCTION_DB_USERNAME=${{ secrets.PRODUCTION_DB_USERNAME }} \

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'io.jsonwebtoken:jjwt:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.15'
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'io.jsonwebtoken:jjwt:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.15'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Docs.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Docs.java
@@ -26,8 +26,7 @@ public interface AppleGameControllerV2Docs {
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "판이 초기화되지 않은 경우",
-                            content = @Content()
+                            description = "판이 초기화되지 않은 경우"
                     ),
                     @ApiResponse(
                             responseCode = "201",

--- a/src/main/java/com/snackgame/server/auth/oauth/config/OAuthConfig.java
+++ b/src/main/java/com/snackgame/server/auth/oauth/config/OAuthConfig.java
@@ -22,8 +22,8 @@ import io.swagger.v3.oas.models.Paths;
 @Profile({"local", "production"})
 public class OAuthConfig {
 
-    public OAuthConfig(Paths customPaths) {
-        addOAuthTo(customPaths);
+    public OAuthConfig(Paths authCustomPaths) {
+        addOAuthTo(authCustomPaths);
     }
 
     @Bean

--- a/src/main/java/com/snackgame/server/auth/token/JwtProviderConfig.java
+++ b/src/main/java/com/snackgame/server/auth/token/JwtProviderConfig.java
@@ -1,5 +1,7 @@
 package com.snackgame.server.auth.token;
 
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,14 +14,14 @@ public class JwtProviderConfig {
     @Bean
     public JwtProvider accessTokenProvider(
             @Value("${security.jwt.token.access-secret-key}") String secretKey,
-            @Value("${security.jwt.token.access-expire-length}") long expireMilliseconds) {
-        return new JwtProvider(secretKey, expireMilliseconds);
+            @Value("${security.jwt.token.access-expiry-days}") long expiryInDays) {
+        return new JwtProvider("accessToken", secretKey, Duration.ofDays(expiryInDays));
     }
 
     @Bean
     public JwtProvider refreshTokenProvider(
             @Value("${security.jwt.token.refresh-secret-key}") String secretKey,
-            @Value("${security.jwt.token.refresh-expire-length}") long expireMilliseconds) {
-        return new JwtProvider(secretKey, expireMilliseconds);
+            @Value("${security.jwt.token.refresh-expiry-days}") long expiryInDays) {
+        return new JwtProvider("refreshToken", secretKey, Duration.ofDays(expiryInDays));
     }
 }

--- a/src/main/java/com/snackgame/server/auth/token/TokenService.java
+++ b/src/main/java/com/snackgame/server/auth/token/TokenService.java
@@ -1,15 +1,12 @@
 package com.snackgame.server.auth.token;
 
-import java.time.Duration;
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.snackgame.server.auth.exception.TokenExpiredException;
 import com.snackgame.server.auth.token.domain.RefreshToken;
 import com.snackgame.server.auth.token.domain.RefreshTokenRepository;
-import com.snackgame.server.auth.token.dto.TokenDto;
+import com.snackgame.server.auth.token.dto.TokensDto;
 import com.snackgame.server.auth.token.util.JwtProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -17,34 +14,25 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class TokenService {
-    @Value("${security.jwt.token.refresh-expire-length}")
-    private long refreshTokenExpiry;
-
-    @Value("${security.jwt.token.access-expire-length}")
-    private long accessTokenExpiry;
 
     private final JwtProvider accessTokenProvider;
     private final JwtProvider refreshTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
-    public TokenDto issueFor(Long memberId) {
-        return new TokenDto(
+    public TokensDto issueFor(Long memberId) {
+        return new TokensDto(
                 issueAccessTokenFor(memberId),
-                issueRefreshTokenFor(memberId),
-                Duration.ofSeconds(accessTokenExpiry),
-                Duration.ofSeconds(refreshTokenExpiry)
+                issueRefreshTokenFor(memberId)
         );
     }
 
     @Transactional
-    public TokenDto reissueFrom(String refreshToken) {
+    public TokensDto reissueFrom(String refreshToken) {
         handleExpiration(() -> refreshTokenProvider.validate(refreshToken));
-        return new TokenDto(
+        return new TokensDto(
                 reissueAccessTokenFrom(refreshToken),
-                reissueRefreshTokenFrom(refreshToken),
-                Duration.ofSeconds(accessTokenExpiry),
-                Duration.ofSeconds(refreshTokenExpiry)
+                reissueRefreshTokenFrom(refreshToken)
         );
     }
 

--- a/src/main/java/com/snackgame/server/auth/token/dto/TokensDto.java
+++ b/src/main/java/com/snackgame/server/auth/token/dto/TokensDto.java
@@ -1,16 +1,12 @@
 package com.snackgame.server.auth.token.dto;
 
-import java.time.Duration;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public class TokenDto {
+public class TokensDto {
 
     private final String accessToken;
     private final String refreshToken;
-    private final Duration accessTokenExpiry;
-    private final Duration refreshTokenExpiry;
 }

--- a/src/main/java/com/snackgame/server/auth/token/support/TokenToCookies.java
+++ b/src/main/java/com/snackgame/server/auth/token/support/TokenToCookies.java
@@ -1,0 +1,51 @@
+package com.snackgame.server.auth.token.support;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import com.snackgame.server.auth.token.dto.TokensDto;
+import com.snackgame.server.auth.token.util.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TokenToCookies {
+
+    private static final String EMPTY = "";
+    private static final String SAME_SITE_OPTION = "None";
+
+    private final JwtProvider accessTokenProvider;
+    private final JwtProvider refreshTokenProvider;
+
+    public String[] from(TokensDto tokens) {
+        return new String[] {
+                baseCookieFrom(accessTokenProvider.getCanonicalName(), tokens.getAccessToken())
+                        .path("/")
+                        .build().toString(),
+                baseCookieFrom(refreshTokenProvider.getCanonicalName(), tokens.getRefreshToken())
+                        .path("/tokens/me")
+                        .build()
+                        .toString()
+        };
+    }
+
+    public String[] empty() {
+        return new String[] {
+                baseCookieFrom(accessTokenProvider.getCanonicalName(), EMPTY)
+                        .path("/")
+                        .build().toString(),
+                ResponseCookie.from(refreshTokenProvider.getCanonicalName(), EMPTY)
+                        .path("/tokens/me")
+                        .build().toString()
+        };
+    }
+
+    private ResponseCookie.ResponseCookieBuilder baseCookieFrom(String name, String value) {
+        return ResponseCookie.from(name, value)
+                .maxAge(refreshTokenProvider.getExpiry())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite(SAME_SITE_OPTION);
+    }
+}

--- a/src/main/java/com/snackgame/server/auth/token/support/TokenToCookies.java
+++ b/src/main/java/com/snackgame/server/auth/token/support/TokenToCookies.java
@@ -35,7 +35,7 @@ public class TokenToCookies {
                 baseCookieFrom(accessTokenProvider.getCanonicalName(), EMPTY)
                         .path("/")
                         .build().toString(),
-                ResponseCookie.from(refreshTokenProvider.getCanonicalName(), EMPTY)
+                baseCookieFrom(refreshTokenProvider.getCanonicalName(), EMPTY)
                         .path("/tokens/me")
                         .build().toString()
         };

--- a/src/main/java/com/snackgame/server/auth/token/support/TokensFromCookie.java
+++ b/src/main/java/com/snackgame/server/auth/token/support/TokensFromCookie.java
@@ -1,0 +1,13 @@
+package com.snackgame.server.auth.token.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface TokensFromCookie {
+
+    boolean refreshTokenValidated() default false;
+}

--- a/src/main/java/com/snackgame/server/auth/token/support/TokensResolver.java
+++ b/src/main/java/com/snackgame/server/auth/token/support/TokensResolver.java
@@ -1,0 +1,63 @@
+package com.snackgame.server.auth.token.support;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.util.WebUtils;
+
+import com.snackgame.server.auth.exception.TokenUnresolvableException;
+import com.snackgame.server.auth.token.dto.TokensDto;
+import com.snackgame.server.auth.token.util.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TokensResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider accessTokenProvider;
+    private final JwtProvider refreshTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(TokensFromCookie.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        validateAnnotationFrom(parameter);
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        return new TokensDto(
+                extractCookieFrom(request, accessTokenProvider.getCanonicalName()),
+                extractCookieFrom(request, refreshTokenProvider.getCanonicalName())
+        );
+    }
+
+    private String extractCookieFrom(HttpServletRequest request, String cookieName) {
+        Cookie cookie = WebUtils.getCookie(request, cookieName);
+        if (cookie != null) {
+            return cookie.getValue();
+        }
+        throw new TokenUnresolvableException();
+    }
+
+    private void validateAnnotationFrom(MethodParameter methodParameter) {
+        TokensFromCookie annotation = methodParameter.getParameterAnnotation(TokensFromCookie.class);
+        if (annotation.refreshTokenValidated()) {
+            throw new NotImplementedException("구현되지 않은 기능을 사용했습니다");
+        }
+    }
+}

--- a/src/main/java/com/snackgame/server/auth/token/util/KeyLocator.java
+++ b/src/main/java/com/snackgame/server/auth/token/util/KeyLocator.java
@@ -1,0 +1,24 @@
+package com.snackgame.server.auth.token.util;
+
+import java.security.Key;
+
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.LocatorAdapter;
+
+public class KeyLocator extends LocatorAdapter<Key> {
+
+    private final Key key;
+
+    public KeyLocator(Key key) {
+        this.key = key;
+    }
+
+    @Override
+    protected Key locate(JwsHeader header) {
+        return key;
+    }
+
+    public Key getKey() {
+        return key;
+    }
+}

--- a/src/main/java/com/snackgame/server/config/OpenApiConfig.java
+++ b/src/main/java/com/snackgame/server/config/OpenApiConfig.java
@@ -1,14 +1,18 @@
 package com.snackgame.server.config;
 
 import java.util.Arrays;
+import java.util.List;
 
+import org.springdoc.core.GroupedOpenApi;
 import org.springdoc.core.SpringDocUtils;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
-import com.snackgame.server.auth.token.support.Authenticated;
 import com.snackgame.server.auth.oauth.support.JustAuthenticated;
+import com.snackgame.server.auth.token.support.Authenticated;
+import com.snackgame.server.auth.token.support.TokensFromCookie;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -21,49 +25,94 @@ import io.swagger.v3.oas.models.servers.Server;
 @Configuration
 public class OpenApiConfig {
 
-    private static final String JWT_SECURITY_KEY = "jwtAuth";
-    private static final SecurityRequirement JWT_SECURITY_ITEM = new SecurityRequirement().addList(
-            "jwtAuth"
-    );
+    private static final String ACCESS_TOKEN_SECURITY_KEY = "accessToken";
+    private static final String REFRESH_TOKEN_SECURITY_KEY = "refreshToken";
 
     static {
         SpringDocUtils.getConfig()
-                .addAnnotationsToIgnore(Authenticated.class, JustAuthenticated.class);
+                .addAnnotationsToIgnore(Authenticated.class, JustAuthenticated.class, TokensFromCookie.class);
     }
 
     @Bean
     public OpenAPI openApiSpecification() {
         return new OpenAPI()
                 .info(new Info()
-                        .version("v0.0.1")
+                        .version("v1.0")
                         .title("스낵게임 API")
                 )
-                .paths(customPaths())
                 .components(new Components()
-                        .addSecuritySchemes(JWT_SECURITY_KEY, jwtSecurityScheme())
+                        .addSecuritySchemes(ACCESS_TOKEN_SECURITY_KEY, accessTokenSecurityScheme())
+                        .addSecuritySchemes(REFRESH_TOKEN_SECURITY_KEY, refreshTokenSecurityScheme())
                 )
                 .addServersItem(new Server().url("/"));
     }
 
+    @Order(1)
     @Bean
-    public Paths customPaths() {
+    public GroupedOpenApi userApis() {
+        return GroupedOpenApi.builder()
+                .group("1-user")
+                .displayName("일반 사용자 API")
+                .pathsToExclude("/tokens/**")
+                .build()
+                .addAllOperationCustomizer(List.of(accessTokenOperationMarker(), refreshTokenOperationMarker()));
+    }
+
+    @Order(2)
+    @Bean
+    public GroupedOpenApi authApis() {
+        return GroupedOpenApi.builder()
+                .group("2-auth")
+                .displayName("인증 API")
+                .pathsToMatch("/tokens/**")
+                .addOpenApiCustomiser(openApi -> {
+                    authCustomPaths().putAll(openApi.getPaths());
+                    openApi.paths(authCustomPaths());
+                })
+                .build()
+                .addAllOperationCustomizer(List.of(accessTokenOperationMarker(), refreshTokenOperationMarker()));
+    }
+
+    @Bean
+    public Paths authCustomPaths() {
         return new Paths();
     }
 
-    private SecurityScheme jwtSecurityScheme() {
+    private SecurityScheme accessTokenSecurityScheme() {
         return new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT");
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("accessToken");
     }
 
-    @Bean
-    public OperationCustomizer authOperationMarker() {
+    private SecurityScheme refreshTokenSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("refreshToken");
+    }
+
+    public OperationCustomizer accessTokenOperationMarker() {
         return (operation, handlerMethod) -> {
             Arrays.stream(handlerMethod.getMethodParameters())
                     .filter(it -> it.hasParameterAnnotation(Authenticated.class))
                     .findAny()
-                    .ifPresent(it -> operation.addSecurityItem(JWT_SECURITY_ITEM));
+                    .ifPresent(it -> operation.addSecurityItem(new SecurityRequirement()
+                            .addList(ACCESS_TOKEN_SECURITY_KEY)
+                    ));
+            return operation;
+        };
+    }
+
+    public OperationCustomizer refreshTokenOperationMarker() {
+        return (operation, handlerMethod) -> {
+            Arrays.stream(handlerMethod.getMethodParameters())
+                    .filter(it -> it.hasParameterAnnotation(TokensFromCookie.class))
+                    .findAny()
+                    .ifPresent(it -> operation.addSecurityItem(new SecurityRequirement()
+                            .addList(ACCESS_TOKEN_SECURITY_KEY)
+                            .addList(REFRESH_TOKEN_SECURITY_KEY)
+                    ));
             return operation;
         };
     }

--- a/src/main/java/com/snackgame/server/config/OpenApiConfig.java
+++ b/src/main/java/com/snackgame/server/config/OpenApiConfig.java
@@ -8,7 +8,6 @@ import org.springdoc.core.SpringDocUtils;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 
 import com.snackgame.server.auth.oauth.support.JustAuthenticated;
 import com.snackgame.server.auth.token.support.Authenticated;
@@ -47,7 +46,6 @@ public class OpenApiConfig {
                 .addServersItem(new Server().url("/"));
     }
 
-    @Order(1)
     @Bean
     public GroupedOpenApi userApis() {
         return GroupedOpenApi.builder()
@@ -58,7 +56,6 @@ public class OpenApiConfig {
                 .addAllOperationCustomizer(List.of(accessTokenOperationMarker(), refreshTokenOperationMarker()));
     }
 
-    @Order(2)
     @Bean
     public GroupedOpenApi authApis() {
         return GroupedOpenApi.builder()

--- a/src/main/java/com/snackgame/server/config/WebMvcConfig.java
+++ b/src/main/java/com/snackgame/server/config/WebMvcConfig.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.snackgame.server.auth.token.support.JwtMemberArgumentResolver;
 import com.snackgame.server.auth.oauth.support.SocialMemberSavingArgumentResolver;
+import com.snackgame.server.auth.token.support.TokensResolver;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,11 +20,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private static final String HOST_NAME = "snackga.me";
 
+    private final TokensResolver tokensResolver;
     private final JwtMemberArgumentResolver jwtMemberArgumentResolver;
     private final SocialMemberSavingArgumentResolver socialMemberSavingArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(tokensResolver);
         resolvers.add(jwtMemberArgumentResolver);
         resolvers.add(socialMemberSavingArgumentResolver);
     }

--- a/src/main/java/com/snackgame/server/member/controller/AuthController.java
+++ b/src/main/java/com/snackgame/server/member/controller/AuthController.java
@@ -1,11 +1,8 @@
 package com.snackgame.server.member.controller;
 
-import java.time.Duration;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,7 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.snackgame.server.auth.oauth.support.JustAuthenticated;
 import com.snackgame.server.auth.token.TokenService;
-import com.snackgame.server.auth.token.dto.TokenDto;
+import com.snackgame.server.auth.token.dto.TokensDto;
+import com.snackgame.server.auth.token.support.TokenToCookies;
+import com.snackgame.server.auth.token.support.TokensFromCookie;
 import com.snackgame.server.member.MemberService;
 import com.snackgame.server.member.controller.dto.MemberDetailsWithTokenResponse;
 import com.snackgame.server.member.controller.dto.NameRequest;
@@ -29,30 +28,30 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
-    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-
-    private final MemberService memberService;
+    private final TokenToCookies tokenToCookies;
     private final TokenService tokenService;
+    private final MemberService memberService;
 
     @Operation(summary = "게스트 토큰 발급", description = "임시 사용자를 생성하고, 토큰을 발급한다")
     @PostMapping("/tokens/guest")
     public ResponseEntity<MemberDetailsWithTokenResponse> issueToken() {
         Member guest = memberService.createGuest();
-        TokenDto token = tokenService.issueFor(guest.getId());
+        TokensDto tokens = tokenService.issueFor(guest.getId());
 
-        return responseWith(token)
-                .body(MemberDetailsWithTokenResponse.of(guest, token.getAccessToken()));
+        return ResponseEntity.ok()
+                .header(SET_COOKIE, tokenToCookies.from(tokens))
+                .body(MemberDetailsWithTokenResponse.of(guest, tokens.getAccessToken()));
     }
 
     @Operation(summary = "일반 사용자 토큰 발급", description = "사용자의 이름으로 토큰을 발급한다")
     @PostMapping("/tokens")
     public ResponseEntity<MemberDetailsWithTokenResponse> issueToken(@RequestBody NameRequest nameRequest) {
         Member member = memberService.getBy(nameRequest.getName());
-        TokenDto token = tokenService.issueFor(member.getId());
+        TokensDto tokens = tokenService.issueFor(member.getId());
 
-        return responseWith(token)
-                .body(MemberDetailsWithTokenResponse.of(member, token.getAccessToken()));
+        return ResponseEntity.ok()
+                .header(SET_COOKIE, tokenToCookies.from(tokens))
+                .body(MemberDetailsWithTokenResponse.of(member, tokens.getAccessToken()));
     }
 
     @Operation(
@@ -62,10 +61,11 @@ public class AuthController {
     )
     @PostMapping("/tokens/social")
     public ResponseEntity<MemberDetailsWithTokenResponse> issueToken(@JustAuthenticated SocialMember socialMember) {
-        TokenDto token = tokenService.issueFor(socialMember.getId());
+        TokensDto tokens = tokenService.issueFor(socialMember.getId());
 
-        return responseWith(token)
-                .body(MemberDetailsWithTokenResponse.of(socialMember, token.getAccessToken()));
+        return ResponseEntity.ok()
+                .header(SET_COOKIE, tokenToCookies.from(tokens))
+                .body(MemberDetailsWithTokenResponse.of(socialMember, tokens.getAccessToken()));
     }
 
     @Operation(
@@ -76,10 +76,11 @@ public class AuthController {
                           + "`LOGOUT`: 리프레시 토큰이 만료되어 토큰 재발급이 불가, 로그아웃 해야한다"
     )
     @PatchMapping("/tokens/me")
-    public ResponseEntity<TokenResponse> reissueToken(@CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
-        TokenDto reissued = tokenService.reissueFrom(refreshToken);
+    public ResponseEntity<TokenResponse> reissueToken(@TokensFromCookie TokensDto tokens) {
+        TokensDto reissued = tokenService.reissueFrom(tokens.getRefreshToken());
 
-        return responseWith(reissued)
+        return ResponseEntity.ok()
+                .header(SET_COOKIE, tokenToCookies.from(reissued))
                 .body(new TokenResponse(reissued.getAccessToken()));
     }
 
@@ -88,46 +89,11 @@ public class AuthController {
             description = "쿠키에 저장된 토큰을 제거한다"
     )
     @DeleteMapping("/tokens/me")
-    public ResponseEntity<Void> logout(@CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
+    public ResponseEntity<Void> logout(@TokensFromCookie TokensDto tokens) {
+        tokenService.delete(tokens.getRefreshToken());
 
-        tokenService.delete(refreshToken);
-
-        return deleteWith();
-    }
-
-    private ResponseEntity.BodyBuilder responseWith(TokenDto token) {
-        return responseEntityBuilder(token.getAccessToken(), token.getRefreshToken(),
-                token.getAccessTokenExpiry(), token.getRefreshTokenExpiry());
-    }
-
-    private ResponseEntity deleteWith() {
-        return responseEntityBuilder(null, null, Duration.ZERO, Duration.ZERO).build();
-    }
-
-    private ResponseEntity.BodyBuilder responseEntityBuilder(
-            String accessToken,
-            String refreshToken,
-            Duration accessAge,
-            Duration refreshAge) {
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE,
-                        ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-                                .path("/tokens/me")
-                                .maxAge(refreshAge)
-                                .httpOnly(true)
-                                .sameSite("None")
-                                .secure(true)
-                                .build()
-                                .toString(),
-                        ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
-                                .path("/")
-                                .maxAge(accessAge)
-                                .httpOnly(true)
-                                .sameSite("None")
-                                .secure(true)
-                                .build()
-                                .toString()
-                );
+                .header(SET_COOKIE, tokenToCookies.empty())
+                .build();
     }
-
 }

--- a/src/main/java/com/snackgame/server/member/controller/AuthController.java
+++ b/src/main/java/com/snackgame/server/member/controller/AuthController.java
@@ -71,9 +71,9 @@ public class AuthController {
     @Operation(
             summary = "토큰 재발급",
             description = "리프레시 토큰으로 토큰을 재발급한다\n\n"
-                          + "**예외 조치 종류**\n\n"
-                          + "`REISSUE`: 액세스 토큰 재발급이 필요하다\n\n"
-                          + "`LOGOUT`: 리프레시 토큰이 만료되어 토큰 재발급이 불가, 로그아웃 해야한다"
+                          + "**각 상황에 대한 응답**\n\n"
+                          + "액세스 토큰만 만료된 경우: `401 UNAUTHORIZED` + action: `REISSUE`\n\n"
+                          + "리프레시 토큰도 만료된 경우: `401 UNAUTHORIZED`"
     )
     @PatchMapping("/tokens/me")
     public ResponseEntity<TokenResponse> reissueToken(@TokensFromCookie TokensDto tokens) {

--- a/src/main/java/com/snackgame/server/member/controller/AuthController.java
+++ b/src/main/java/com/snackgame/server/member/controller/AuthController.java
@@ -22,6 +22,9 @@ import com.snackgame.server.member.domain.Member;
 import com.snackgame.server.member.domain.SocialMember;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -71,9 +74,33 @@ public class AuthController {
     @Operation(
             summary = "토큰 재발급",
             description = "리프레시 토큰으로 토큰을 재발급한다\n\n"
-                          + "**각 상황에 대한 응답**\n\n"
-                          + "액세스 토큰만 만료된 경우: `401 UNAUTHORIZED` + action: `REISSUE`\n\n"
-                          + "리프레시 토큰도 만료된 경우: `401 UNAUTHORIZED`"
+                          + "**각 상황에 대한 응답은 하단 참고**",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "액세스 토큰이 만료되었을 때, 인증이 필요한 API를 호출한 경우",
+                            content = @Content(examples = @ExampleObject(
+                                    "{\n"
+                                    + "  \"action\": \"REISSUE\",\n"
+                                    + "  \"messages\": [\n"
+                                    + "    \"토큰이 만료되었습니다\"\n"
+                                    + "  ]\n"
+                                    + "}"
+                            ))
+                    ),
+                    @ApiResponse(
+                            responseCode = "401 ",
+                            description = "리프레시 토큰도 만료되었을 때, 인증이 필요한 API를 호출한 경우",
+                            content = @Content(examples = @ExampleObject(
+                                    "{\n"
+                                    + "  \"action\": null,\n"
+                                    + "  \"messages\": [\n"
+                                    + "    \"토큰을 읽지 못했습니다\"\n"
+                                    + "  ]\n"
+                                    + "}"
+                            ))
+                    )
+            }
     )
     @PatchMapping("/tokens/me")
     public ResponseEntity<TokenResponse> reissueToken(@TokensFromCookie TokensDto tokens) {

--- a/src/main/java/com/snackgame/server/member/controller/MemberController.java
+++ b/src/main/java/com/snackgame/server/member/controller/MemberController.java
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.snackgame.server.auth.oauth.support.JustAuthenticated;
 import com.snackgame.server.auth.token.support.Authenticated;
 import com.snackgame.server.auth.token.util.JwtProvider;
-import com.snackgame.server.auth.oauth.support.JustAuthenticated;
 import com.snackgame.server.member.MemberService;
 import com.snackgame.server.member.controller.dto.GroupRequest;
 import com.snackgame.server.member.controller.dto.MemberDetailsResponse;
@@ -78,23 +78,5 @@ public class MemberController {
         Member integrated = memberService.integrate(victim, socialMember);
         String token = accessTokenProvider.createTokenWith(integrated.getId().toString());
         return MemberDetailsWithTokenResponse.of(integrated, token);
-    }
-
-    @Deprecated
-    @Operation(summary = "게스트 토큰 발급", description = "추가정보 없이 임시 사용자 토큰을 발급한다")
-    @PostMapping("/members/guest")
-    public MemberDetailsWithTokenResponse addGuest() {
-        Member guest = memberService.createGuest();
-        String accessToken = accessTokenProvider.createTokenWith(guest.getId().toString());
-        return MemberDetailsWithTokenResponse.of(guest, accessToken);
-    }
-
-    @Deprecated
-    @Operation(summary = "사용자의 토큰 발급", description = "어떤 이름을 가진 사용자의 토큰을 발급한다")
-    @PostMapping("/members/token")
-    public MemberDetailsWithTokenResponse issueToken(@RequestBody NameRequest nameRequest) {
-        Member found = memberService.getBy(nameRequest.getName());
-        String accessToken = accessTokenProvider.createTokenWith(found.getId().toString());
-        return MemberDetailsWithTokenResponse.of(found, accessToken);
     }
 }

--- a/src/main/java/com/snackgame/server/member/controller/dto/GroupResponse.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/GroupResponse.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import com.snackgame.server.member.domain.Group;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class GroupResponse {
 
+    @Schema(example = "2")
     private final Long id;
+    @Schema(example = "숭실대학교")
     private final String name;
 
     public static GroupResponse of(Group group) {

--- a/src/main/java/com/snackgame/server/member/controller/dto/MemberDetailsResponse.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/MemberDetailsResponse.java
@@ -10,9 +10,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class MemberDetailsResponse {
 
+    @Schema(example = "1")
     private final Long id;
+    @Schema(example = "닉네임")
     private final String name;
-    @Schema(allowableValues = {"SELF", "GUEST", "SOCIAL"})
+    @Schema(example = "SOCIAL", allowableValues = {"SELF", "GUEST", "SOCIAL"})
     private final String type;
     private final GroupResponse group;
 

--- a/src/main/java/com/snackgame/server/member/controller/dto/MemberDetailsWithTokenResponse.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/MemberDetailsWithTokenResponse.java
@@ -2,6 +2,7 @@ package com.snackgame.server.member.controller.dto;
 
 import com.snackgame.server.member.domain.Member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ import lombok.Getter;
 public class MemberDetailsWithTokenResponse {
 
     private MemberDetailsResponse member;
+    @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1NTQiLCJ3MTU0N30.QsyZ")
     private String accessToken;
 
     public static MemberDetailsWithTokenResponse of(Member member, String accessToken) {

--- a/src/main/java/com/snackgame/server/member/controller/dto/MemberRequest.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/MemberRequest.java
@@ -2,6 +2,7 @@ package com.snackgame.server.member.controller.dto;
 
 import javax.validation.constraints.NotBlank;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,7 +10,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemberRequest {
 
+    @Schema(example = "홍길동")
     @NotBlank(message = "이름은 공백일 수 없습니다")
     private String name;
+    @Schema(example = "숭실대학교")
     private String group;
 }

--- a/src/main/java/com/snackgame/server/member/controller/dto/NameRequest.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/NameRequest.java
@@ -2,6 +2,7 @@ package com.snackgame.server.member.controller.dto;
 
 import javax.validation.constraints.NotBlank;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class NameRequest {
 
+    @Schema(example = "홍길동")
     @NotBlank(message = "이름은 공백일 수 없습니다")
     private String name;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,6 +21,6 @@ security:
   jwt:
     token:
       access-secret-key: snackgamelocalsecretkey12345
-      access-expire-length: 86400000
+      access-expiry-days: 7
       refresh-secret-key: snackgamelocalrefreshsecretkey12345
-      refresh-expire-length: 8640000
+      refresh-expiry-days: 30

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -10,9 +10,9 @@ security:
   jwt:
     token:
       access-secret-key: ${JWT_SECRET_KEY}
-      access-expire-length: ${JWT_EXPIRE_LENGTH}
+      access-expiry-days: ${JWT_EXPIRE_LENGTH}
       refresh-secret-key: ${JWT_REFRESH_SECRET_KEY}
-      refresh-expire-length: ${JWT_REFRESH_EXPIRE_LENGTH}
+      refresh-expiry-days: ${JWT_REFRESH_EXPIRE_LENGTH}
 server:
   port: ${APPLICATION_PORT}
   forward-headers-strategy: native

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -9,10 +9,10 @@ spring:
 security:
   jwt:
     token:
-      access-secret-key: ${JWT_SECRET_KEY}
-      access-expiry-days: ${JWT_EXPIRE_LENGTH}
-      refresh-secret-key: ${JWT_REFRESH_SECRET_KEY}
-      refresh-expiry-days: ${JWT_REFRESH_EXPIRE_LENGTH}
+      access-secret-key: ${ACCESS_TOKEN_SECRET_KEY}
+      access-expiry-days: ${ACCESS_TOKEN_EXPIRY_DAYS}
+      refresh-secret-key: ${REFRESH_TOKEN_SECRET_KEY}
+      refresh-expiry-days: ${REFRESH_TOKEN_EXPIRY_DAYS}
 server:
   port: ${APPLICATION_PORT}
   forward-headers-strategy: native

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -10,6 +10,6 @@ security:
   jwt:
     token:
       access-secret-key: testsecretkey1234567890
-      access-expire-length: 86400000
+      access-expiry-days: 7
       refresh-secret-key: testrefreshsecretkey1234567890
-      refresh-expire-length: 8640000
+      refresh-expiry-days: 30

--- a/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/snackgame/server/member/controller/AuthControllerTest.java
@@ -25,7 +25,7 @@ class AuthControllerTest {
 
     @Test
     void 토큰을_발급한다() {
-        Cookies cookies = RestAssured.given().log().all()
+        var cookies = RestAssured.given().log().all()
                 .when().post("/tokens/guest")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
@@ -36,7 +36,6 @@ class AuthControllerTest {
 
         assertThat(cookies.get("accessToken").getSameSite()).isEqualTo("None");
         assertThat(cookies.get("refreshToken").getSameSite()).isEqualTo("None");
-
     }
 
     @Test
@@ -50,21 +49,21 @@ class AuthControllerTest {
 
     @Test
     void 리프레시_토큰으로_토큰을_재발급한다() throws InterruptedException {
-        Cookie refreshToken = RestAssured.given()
+        var cookies = RestAssured.given()
                 .when().post("/tokens/guest")
-                .then().extract().detailedCookie("refreshToken");
+                .then().extract().detailedCookies();
 
         Thread.sleep(1000);
 
         RestAssured.given().log().all()
-                .cookie(refreshToken)
+                .cookies(cookies)
                 .when().patch("/tokens/me")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("accessToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
                 .cookie("refreshToken", startsWith("eyJhbGciOiJIUzI1NiJ9"))
-                .cookie("refreshToken", not(refreshToken.getValue()));
+                .cookie("refreshToken", not(cookies.getValue("refreshToken")));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- #97

## 변경 사항
### AS-IS
액세스 토큰의 쿠키 maxAge가 너무 짧은 관계로 만료 여부를 서버가 구분해 줄 수 없었음.

### TO-BE
액세스 토큰의 쿠키 maxAge를 리프레시 토큰만큼 연장
관련한 예외 응답 문서화
  <img width="658" alt="image" src="https://github.com/snack-game/server/assets/39221443/a1a578f0-e46e-4bad-a7b6-270ea197b564">

### 그 외
- '일' 기준 Expiry 설정(헷갈리지 않도록)
- 환경 변수 이름 변경 및 오래된 토큰 secret 변경
  <img width="449" alt="image" src="https://github.com/snack-game/server/assets/39221443/3003b03e-ee05-4e59-98ab-5b60b9cc0a14">
