### PR TITLE
fix: 게스트와 소셜 계정 점수 통합 버그 수정

### DIFF
--- a/src/main/java/com/snackgame/server/rank/applegame/domain/AppleGameBestScoreTransfer.java
+++ b/src/main/java/com/snackgame/server/rank/applegame/domain/AppleGameBestScoreTransfer.java
@@ -27,8 +27,9 @@ public class AppleGameBestScoreTransfer implements BestScoreTransfer {
         BestScore victimBestScore = bestScores.getByOwnerIdAndSeasonId(victimMemberId, season.getId());
         BestScore currentBestScore = bestScores.getByOwnerIdAndSeasonId(currentMemberId, season.getId());
 
-        if (victimBestScore != BestScore.EMPTY && currentBestScore.beats(victimBestScore)) {
+        if (victimBestScore != BestScore.EMPTY && victimBestScore.beats(currentBestScore)) {
             victimBestScore.transferTo(currentBestScore.getOwnerId());
+            bestScores.delete(currentBestScore);
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #99 

## 변경 사항
### AS-IS

1. 게스트 점수와 소셜 계정 점수의 비교가 반대로 되어있었다.
2. 점수 통합 과정에서 소셜 계정 점수를 삭제하지 않아 `Best Score`가 두개 생길 수 있었다.

### TO-BE

1. 점수 비교 순서 변경
2. 소셜 계정 점수를 삭제해주는 과정을 추가하였다. 
