### PR TITLE
feat: 현재 레벨의 최대경험치를 알 수 있다

### DIFF
--- a/src/main/java/com/snackgame/server/member/controller/dto/StatusResponse.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/StatusResponse.java
@@ -10,12 +10,14 @@ import lombok.RequiredArgsConstructor;
 public class StatusResponse {
 
     private final Long level;
-
     private final Double exp;
+    private final Double maxExp;
 
     public static StatusResponse of(Status status) {
         return new StatusResponse(
                 status.getLevel(),
-                status.getExp().doubleValue());
+                status.getExp().doubleValue(),
+                status.expRequiredForLevel().doubleValue()
+        );
     }
 }

--- a/src/main/java/com/snackgame/server/member/controller/dto/StatusResponse.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/StatusResponse.java
@@ -2,6 +2,7 @@ package com.snackgame.server.member.controller.dto;
 
 import com.snackgame.server.member.domain.Status;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,8 +10,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class StatusResponse {
 
+    @Schema(example = "1")
     private final Long level;
+    @Schema(example = "200")
     private final Double exp;
+    @Schema(example = "240")
     private final Double maxExp;
 
     public static StatusResponse of(Status status) {

--- a/src/main/java/com/snackgame/server/member/domain/Status.java
+++ b/src/main/java/com/snackgame/server/member/domain/Status.java
@@ -16,7 +16,7 @@ public class Status {
     private static final double MULTIPLIER = 1.2;
 
     @Column(name = "level")
-    private long level = 0;
+    private Long level = 0L;
 
     @Column(name = "exp")
     private BigDecimal exp = ZERO;
@@ -24,16 +24,20 @@ public class Status {
     public Status() {
     }
 
+    public Status(Long level) {
+        this.level = level;
+    }
+
     public void addExp(double amount) {
         BigDecimal remainingExp = exp.add(BigDecimal.valueOf(amount));
-        while (remainingExp.compareTo(expRequiredFor(level)) >= 0) {
-            remainingExp = remainingExp.subtract(expRequiredFor(level));
+        while (remainingExp.compareTo(expRequiredForLevel()) >= 0) {
+            remainingExp = remainingExp.subtract(expRequiredForLevel());
             addLevel();
         }
         this.exp = remainingExp;
     }
 
-    private BigDecimal expRequiredFor(Long level) {
+    public BigDecimal expRequiredForLevel() {
         BigDecimal weight = BigDecimal.valueOf(MULTIPLIER).pow(level.intValue());
         return BigDecimal.valueOf(200).multiply(weight);
     }
@@ -41,5 +45,4 @@ public class Status {
     private void addLevel() {
         this.level += 1;
     }
-
 }

--- a/src/test/java/com/snackgame/server/member/domain/StatusTest.java
+++ b/src/test/java/com/snackgame/server/member/domain/StatusTest.java
@@ -12,11 +12,19 @@ import org.junit.jupiter.params.provider.CsvSource;
 class StatusTest {
 
     @ParameterizedTest
-    @CsvSource({"200,1", "440,2", "728,3", "1073.6,4"})
+    @CsvSource({"200,1", "440,2", "728,3", "1073.5,3", "1073.6,4"})
     void 레벨업_한다(double expAmount, int expectedLevel) {
         Status status = new Status();
 
         status.addExp(expAmount);
         assertThat(status.getLevel()).isEqualTo(expectedLevel);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 200", "1, 240", "2, 288", "3, 345.6"})
+    void 현재_레벨의_최대경험치를_알_수_있다(Long level, Double requiredExp) {
+        Status status = new Status(level);
+
+        assertThat(status.expRequiredForLevel().doubleValue()).isEqualTo(requiredExp);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- [FE PR] https://github.com/snack-game/front/pull/148#discussion_r1501771088

<!-- (위 정보는 생략 가능) -->

## 변경 사항
### AS-IS
현재 레벨의 최대 경험치를 내부적으로만 사용했다.
### TO-BE
최대 경험치도 응답에 싣는다.