### PR TITLE
feat: 프로필 이미지를 추가한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
           submodules: true
           token: ${{ steps.app_token.outputs.token }}
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'corretto'
 
       - name: Grant execute permission for gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.12'
 	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 sourceCompatibility = '11'
@@ -21,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 	implementation 'io.jsonwebtoken:jjwt:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
@@ -36,9 +38,20 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'
+	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 	systemProperty("spring.profiles.active", "test")
+}
+compileKotlin {
+	kotlinOptions {
+		jvmTarget = "17"
+	}
+}
+compileTestKotlin {
+	kotlinOptions {
+		jvmTarget = "17"
+	}
 }

--- a/src/main/java/com/snackgame/server/common/file/ResourceResolver.kt
+++ b/src/main/java/com/snackgame/server/common/file/ResourceResolver.kt
@@ -1,0 +1,19 @@
+package com.snackgame.server.common.file
+
+import org.springframework.core.io.Resource
+import org.springframework.core.io.UrlResource
+import org.springframework.stereotype.Component
+import java.net.URL
+
+@Component
+class ResourceResolver(
+    private val s3FileUploader: S3FileUploader
+) {
+
+    fun resolve(resource: Resource): URL {
+        return when (resource) {
+            is UrlResource -> resource.url
+            else -> s3FileUploader.upload(resource)
+        }
+    }
+}

--- a/src/main/java/com/snackgame/server/common/file/S3FileUploader.kt
+++ b/src/main/java/com/snackgame/server/common/file/S3FileUploader.kt
@@ -1,0 +1,44 @@
+package com.snackgame.server.common.file
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ObjectMetadata
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.Resource
+import org.springframework.stereotype.Component
+import java.io.IOException
+import java.net.URL
+import java.util.*
+import java.util.stream.Collectors
+
+@Component
+class S3FileUploader(
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucket: String,
+    private val amazonS3Client: AmazonS3
+) {
+
+    fun upload(resource: Resource): URL {
+        return uploadToS3(resource)
+    }
+
+    fun upload(resources: List<Resource>): List<URL> {
+        return resources.parallelStream()
+            .map(::upload)
+            .collect(Collectors.toList())
+    }
+
+    @Throws(IOException::class)
+    private fun uploadToS3(resource: Resource): URL {
+        val key = uniquePathOf(resource)
+        val metadata = ObjectMetadata().let {
+            it.contentLength = resource.contentLength()
+            it
+        }
+        amazonS3Client.putObject(bucket, key, resource.inputStream, metadata)
+        return amazonS3Client.getUrl(bucket, key)
+    }
+
+    private fun uniquePathOf(resource: Resource): String {
+        return "unhashed/${UUID.randomUUID()}-${resource.filename}"
+    }
+}

--- a/src/main/java/com/snackgame/server/config/S3Config.java
+++ b/src/main/java/com/snackgame/server/config/S3Config.java
@@ -1,0 +1,42 @@
+package com.snackgame.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+@Configuration
+public class S3Config {
+
+    @Profile("production")
+    @Bean
+    public AmazonS3 amazonS3OnInstance() {
+        return AmazonS3Client.builder()
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .withCredentials(InstanceProfileCredentialsProvider.getInstance())
+                .build();
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(
+            @Value("${cloud.aws.credentials.access-key}")
+            String accessKey,
+            @Value("${cloud.aws.credentials.secret-key}")
+            String secretKey
+    ) {
+        AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(accessKey, secretKey));
+        return AmazonS3Client.builder()
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .withCredentials(credentialsProvider)
+                .build();
+    }
+}

--- a/src/main/java/com/snackgame/server/member/MemberAccountService.java
+++ b/src/main/java/com/snackgame/server/member/MemberAccountService.java
@@ -1,12 +1,15 @@
 package com.snackgame.server.member;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.snackgame.server.common.file.ResourceResolver;
 import com.snackgame.server.member.domain.AccountTransfer;
 import com.snackgame.server.member.domain.DistinctNaming;
 import com.snackgame.server.member.domain.Group;
@@ -14,8 +17,8 @@ import com.snackgame.server.member.domain.Guest;
 import com.snackgame.server.member.domain.Member;
 import com.snackgame.server.member.domain.MemberRepository;
 import com.snackgame.server.member.domain.Name;
+import com.snackgame.server.member.domain.ProfileImage;
 import com.snackgame.server.member.domain.SocialMember;
-import com.snackgame.server.member.domain.Status;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,6 +31,8 @@ public class MemberAccountService {
     private final GroupService groupService;
     private final DistinctNaming distinctNaming;
     private final AccountTransfer accountTransfer;
+
+    private final ResourceResolver resourceResolver;
 
     @Transactional
     public Member createWith(String name) {
@@ -72,6 +77,13 @@ public class MemberAccountService {
         Member member = members.getById(memberId);
         Group group = groupService.createIfNotExists(groupName);
         member.changeGroupTo(group);
+    }
+
+    @Transactional
+    public void changeProfileImageOf(Long memberId, Resource resource) {
+        Member member = members.getById(memberId);
+        URL resolved = resourceResolver.resolve(resource);
+        member.changeProfileImageTo(new ProfileImage(resolved.toString()));
     }
 
     public Member getBy(Long id) {

--- a/src/main/java/com/snackgame/server/member/MemberAccountService.java
+++ b/src/main/java/com/snackgame/server/member/MemberAccountService.java
@@ -39,7 +39,7 @@ public class MemberAccountService {
         Name newName = new Name(name);
         distinctNaming.validate(newName);
 
-        Member newMember = new Member(newName, new Status());
+        Member newMember = new Member(newName);
         if (Objects.nonNull(groupName)) {
             newMember.changeGroupTo(groupService.createIfNotExists(groupName));
         }
@@ -48,7 +48,7 @@ public class MemberAccountService {
 
     @Transactional
     public Member createGuest() {
-        Guest guest = new Guest(distinctNaming.ofGuest(), new Status());
+        Guest guest = new Guest(distinctNaming.ofGuest());
         return members.save(guest);
     }
 

--- a/src/main/java/com/snackgame/server/member/controller/MemberController.java
+++ b/src/main/java/com/snackgame/server/member/controller/MemberController.java
@@ -1,19 +1,27 @@
 package com.snackgame.server.member.controller;
 
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
 import java.util.List;
 
 import javax.validation.Valid;
 
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.snackgame.server.auth.oauth.support.JustAuthenticated;
+import com.snackgame.server.auth.token.TokenService;
+import com.snackgame.server.auth.token.dto.TokensDto;
 import com.snackgame.server.auth.token.support.Authenticated;
-import com.snackgame.server.auth.token.util.JwtProvider;
+import com.snackgame.server.auth.token.support.TokenToCookies;
 import com.snackgame.server.member.MemberAccountService;
 import com.snackgame.server.member.controller.dto.GroupRequest;
 import com.snackgame.server.member.controller.dto.MemberDetailsResponse;
@@ -30,15 +38,15 @@ import lombok.RequiredArgsConstructor;
 @RestController
 public class MemberController {
 
+    private final TokenService tokenService;
+    private final TokenToCookies tokenToCookies;
     private final MemberAccountService memberAccountService;
-    private final JwtProvider accessTokenProvider;
 
     @Operation(summary = "일반 사용자 생성", description = "이름, 그룹으로 사용자를 생성한다")
     @PostMapping("/members")
     public MemberDetailsWithTokenResponse addMember(@Valid @RequestBody MemberRequest memberRequest) {
         Member added = memberAccountService.createWith(memberRequest.getName(), memberRequest.getGroup());
-        String accessToken = accessTokenProvider.createTokenWith(added.getId().toString());
-        return MemberDetailsWithTokenResponse.of(added, accessToken);
+        return MemberDetailsWithTokenResponse.of(added, "DEPRECATED");
     }
 
     @Operation(summary = "모든 이름 검색", description = "인자로 시작하는 모든 사용자 이름을 가져온다")
@@ -53,30 +61,36 @@ public class MemberController {
         return MemberDetailsResponse.of(member);
     }
 
-    @Operation(summary = "나의 그룹 지정", description = "현재 사용자의 그룹을 지정한다")
-    @PutMapping("/members/me/group")
-    public void changeGroup(@Authenticated Member member, @RequestBody GroupRequest groupRequest) {
-        memberAccountService.changeGroupNameOf(member.getId(), groupRequest.getGroup());
-    }
-
     @Operation(summary = "나의 이름 변경", description = "현재 사용자의 이름을 변경한다")
     @PutMapping("/members/me/name")
     public void changeName(@Authenticated Member member, @RequestBody NameRequest nameRequest) {
         memberAccountService.changeNameOf(member.getId(), nameRequest.getName());
     }
 
-    @Operation(
-            summary = "현재 계정을 소셜 계정에 통합",
-            description = "현재 사용자를 소셜 계정으로 통합하고, 토큰을 발급한다.<br>"
-                          + "<b>직전에 소셜 로그인을 수행</b>해야 하고, 이 때 사용했던 <b>SESSION ID를 포함</b>해야 한다."
-    )
+    @Operation(summary = "나의 그룹 지정", description = "현재 사용자의 그룹을 지정한다")
+    @PutMapping("/members/me/group")
+    public void changeGroup(@Authenticated Member member, @RequestBody GroupRequest groupRequest) {
+        memberAccountService.changeGroupNameOf(member.getId(), groupRequest.getGroup());
+    }
+
+    @Operation(summary = "나의 프로필 이미지 변경", description = "현재 사용자의 프로필 이미지를 변경한다")
+    @PutMapping(value = "/members/me/profile-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public void changeProfileImage(@Authenticated Member member, @RequestPart MultipartFile profileImage) {
+        memberAccountService.changeProfileImageOf(member.getId(), profileImage.getResource());
+    }
+
+    @Operation(summary = "현재 계정을 소셜 계정으로 통합",
+            description = "현재 사용자를 직전에 로그인한 소셜 계정으로 통합한다")
     @PostMapping("/members/me/integrate")
-    public MemberDetailsWithTokenResponse integrate(
+    public ResponseEntity<MemberDetailsWithTokenResponse> integrate(
             @Authenticated Member victim,
             @JustAuthenticated SocialMember socialMember
     ) {
         Member integrated = memberAccountService.integrate(victim, socialMember);
-        String token = accessTokenProvider.createTokenWith(integrated.getId().toString());
-        return MemberDetailsWithTokenResponse.of(integrated, token);
+        TokensDto tokens = tokenService.issueFor(integrated.getId());
+
+        return ResponseEntity.ok()
+                .header(SET_COOKIE, tokenToCookies.from(tokens))
+                .body(MemberDetailsWithTokenResponse.of(integrated, "DEPRECATED"));
     }
 }

--- a/src/main/java/com/snackgame/server/member/controller/dto/MemberDetailsResponse.java
+++ b/src/main/java/com/snackgame/server/member/controller/dto/MemberDetailsResponse.java
@@ -14,18 +14,20 @@ public class MemberDetailsResponse {
     private final Long id;
     @Schema(example = "닉네임")
     private final String name;
+    private final GroupResponse group;
+    private final String profileImage;
     private final StatusResponse status;
     @Schema(example = "SOCIAL", allowableValues = {"SELF", "GUEST", "SOCIAL"})
     private final String type;
-    private final GroupResponse group;
 
     public static MemberDetailsResponse of(Member member) {
         return new MemberDetailsResponse(
                 member.getId(),
                 member.getNameAsString(),
+                GroupResponse.of(member.getGroup()),
+                member.getProfileImage().getUrl(),
                 StatusResponse.of(member.getStatus()),
-                member.getAccountType().name(),
-                GroupResponse.of(member.getGroup())
+                member.getAccountType().name()
         );
     }
 }

--- a/src/main/java/com/snackgame/server/member/domain/Guest.java
+++ b/src/main/java/com/snackgame/server/member/domain/Guest.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Guest extends Member {
 
-    public Guest(Name name, Status status) {
-        super(name, status);
+    public Guest(Name name) {
+        super(name);
     }
 
     @Override

--- a/src/main/java/com/snackgame/server/member/domain/Member.java
+++ b/src/main/java/com/snackgame/server/member/domain/Member.java
@@ -30,6 +30,8 @@ public class Member extends BaseEntity {
     @ManyToOne
     private Group group;
     @Embedded
+    private ProfileImage profileImage = ProfileImage.EMPTY;
+    @Embedded
     private final Status status = new Status();
 
     private boolean isValid = true;
@@ -52,8 +54,8 @@ public class Member extends BaseEntity {
         this.group = group;
     }
 
-    public void changeStatusTo(Status status) {
-        this.status = status;
+    public void changeProfileImageTo(ProfileImage profileImage) {
+        this.profileImage = profileImage;
     }
 
     public void invalidate() {

--- a/src/main/java/com/snackgame/server/member/domain/Member.java
+++ b/src/main/java/com/snackgame/server/member/domain/Member.java
@@ -16,10 +16,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
+@Getter
 @Inheritance
 @DiscriminatorColumn(name = "type")
-@Getter
+@Entity
 public class Member extends BaseEntity {
 
     @Id
@@ -30,19 +30,17 @@ public class Member extends BaseEntity {
     @ManyToOne
     private Group group;
     @Embedded
-    private Status status;
+    private final Status status = new Status();
 
     private boolean isValid = true;
 
-    public Member(Name name, Status status) {
+    public Member(Name name) {
         this.name = name;
-        this.status = status;
     }
 
-    public Member(Long id, Name name, Status status, Group group) {
+    public Member(Long id, Name name, Group group) {
         this.id = id;
         this.name = name;
-        this.status = status;
         this.group = group;
     }
 

--- a/src/main/java/com/snackgame/server/member/domain/ProfileImage.java
+++ b/src/main/java/com/snackgame/server/member/domain/ProfileImage.java
@@ -1,0 +1,43 @@
+package com.snackgame.server.member.domain;
+
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import com.snackgame.server.member.exception.InvalidProfileImageException;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class ProfileImage {
+
+    private static final List<String> ALLOWED_SCHEMES = List.of("http", "https");
+
+    public static final ProfileImage EMPTY = new ProfileImage(
+            "https://snackgame.s3.ap-northeast-2.amazonaws.com/static/logo.png");
+
+    @Column(name = "profile_image", nullable = false)
+    private String url;
+
+    public ProfileImage(String url) {
+        validate(url);
+        this.url = url;
+    }
+
+    private void validate(String url) {
+        if (!ALLOWED_SCHEMES.contains(getSchemeOf(url))) {
+            throw new InvalidProfileImageException();
+        }
+    }
+
+    private String getSchemeOf(String url) {
+        return url.split("://")[0];
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/com/snackgame/server/member/domain/SnackgameSocialMemberSaver.java
+++ b/src/main/java/com/snackgame/server/member/domain/SnackgameSocialMemberSaver.java
@@ -21,11 +21,11 @@ public class SnackgameSocialMemberSaver implements SocialMemberSaver<SocialMembe
         SocialMember member = members.findByProviderAndProvidedId(attributes.getProvider(), attributes.getId())
                 .orElseGet(() -> new SocialMember(
                         distinctNaming.from(new Name(attributes.getName())),
-                        new Status(),
                         attributes.getProvider(),
                         attributes.getId()
                 ));
-        member.setAdditional(attributes.getEmail(), attributes.getNickname(), attributes.getPictureUrl());
+        member.changeProfileImageTo(new ProfileImage(attributes.getPictureUrl()));
+        member.setAdditional(attributes.getEmail(), attributes.getNickname());
         return members.save(member);
     }
 }

--- a/src/main/java/com/snackgame/server/member/domain/SocialMember.java
+++ b/src/main/java/com/snackgame/server/member/domain/SocialMember.java
@@ -11,29 +11,20 @@ public class SocialMember extends Member {
 
     private String email;
     private String nickname;
-    private String picture;
 
     private String provider;
     private String providedId;
 
-    public SocialMember(Name name, Status status, String provider, String providedId) {
-        super(name, status);
+    public SocialMember(Name name, String provider, String providedId) {
+        super(name);
         this.provider = provider;
         this.providedId = providedId;
     }
 
-    private SocialMember(Long id, Name name, Status status, Group group, String provider, String providedId) {
-        super(id, name, status, group);
+    public SocialMember(Long id, Name name, Group group, String provider, String providedId) {
+        super(id, name, group);
         this.provider = provider;
         this.providedId = providedId;
-    }
-
-    public static SocialMember from(Member member, String provider, String providedId) {
-        return new SocialMember(
-                member.getId(), member.getName(), member.getStatus(), member.getGroup(),
-                provider,
-                providedId
-        );
     }
 
     public String getProvider() {
@@ -49,9 +40,8 @@ public class SocialMember extends Member {
         return AccountType.SOCIAL;
     }
 
-    public void setAdditional(String email, String nickname, String picture) {
+    public void setAdditional(String email, String nickname) {
         this.email = email;
         this.nickname = nickname;
-        this.picture = picture;
     }
 }

--- a/src/main/java/com/snackgame/server/member/domain/Status.java
+++ b/src/main/java/com/snackgame/server/member/domain/Status.java
@@ -15,10 +15,10 @@ public class Status {
 
     private static final double MULTIPLIER = 1.2;
 
-    @Column(name = "level")
+    @Column(name = "level", nullable = false)
     private Long level = 0L;
 
-    @Column(name = "exp")
+    @Column(name = "exp", nullable = false)
     private BigDecimal exp = ZERO;
 
     public Status() {

--- a/src/main/java/com/snackgame/server/member/exception/InvalidProfileImageException.java
+++ b/src/main/java/com/snackgame/server/member/exception/InvalidProfileImageException.java
@@ -1,0 +1,7 @@
+package com.snackgame.server.member.exception;
+
+public class InvalidProfileImageException extends MemberException {
+    public InvalidProfileImageException() {
+        super("프로필 이미지가 잘못되었습니다");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
   config:
     import:
       - classpath:secrets/oauth-secrets.yml
+      - classpath:secrets/aws-secrets.yml
   mvc:
     throw-exception-if-no-handler-found: true
   web:

--- a/src/test/java/com/snackgame/server/member/MemberAccountServiceTest.java
+++ b/src/test/java/com/snackgame/server/member/MemberAccountServiceTest.java
@@ -63,7 +63,7 @@ class MemberAccountServiceTest {
 
     @Test
     void 임시사용자_이름이_중복이면_다시_만든다() {
-        Guest existing = memberRepository.save(new Guest(new Name("게스트#abc"), new Status()));
+        Guest existing = memberRepository.save(new Guest(new Name("게스트#abc")));
 
         Member guest = memberAccountService.createGuest();
 

--- a/src/test/java/com/snackgame/server/member/domain/GuestTest.java
+++ b/src/test/java/com/snackgame/server/member/domain/GuestTest.java
@@ -15,18 +15,18 @@ class GuestTest {
 
     @Test
     void 게스트는_이름을_변경할_수_없다() {
-        assertThatThrownBy(() -> new Guest(new Name("게스트"), new Status()).changeNameTo(new Name("이름")))
+        assertThatThrownBy(() -> new Guest(new Name("게스트")).changeNameTo(new Name("이름")))
                 .isInstanceOf(GuestRestrictedException.class);
     }
 
     @Test
     void 게스트는_그룹을_변경할_수_없다() {
-        assertThatThrownBy(() -> new Guest(new Name("게스트"), new Status()).changeGroupTo(new Group("그룹")))
+        assertThatThrownBy(() -> new Guest(new Name("게스트")).changeGroupTo(new Group("그룹")))
                 .isInstanceOf(GuestRestrictedException.class);
     }
 
     @Test
     void 게스트의_계정_타입은_GUEST이다() {
-        assertThat(new Guest(new Name("게스트"), new Status()).getAccountType()).isEqualTo(AccountType.GUEST);
+        assertThat(new Guest(new Name("게스트")).getAccountType()).isEqualTo(AccountType.GUEST);
     }
 }

--- a/src/test/java/com/snackgame/server/member/domain/ProfileImageTest.java
+++ b/src/test/java/com/snackgame/server/member/domain/ProfileImageTest.java
@@ -1,0 +1,30 @@
+package com.snackgame.server.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.snackgame.server.member.exception.InvalidProfileImageException;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ProfileImageTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http://image-on-web", "https://image-on-web"})
+    void 허용된_스키마만_사용할_수_있다(String url) {
+        assertThatNoException()
+                .isThrownBy(() -> new ProfileImage(url));
+    }
+
+    @Test
+    void 허용되지_않은_스키마는_예외를_던진다() {
+        assertThatThrownBy(() -> new ProfileImage("ftp://image-from-ftp"))
+                .isInstanceOf(InvalidProfileImageException.class);
+    }
+}

--- a/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
+++ b/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
@@ -7,33 +7,32 @@ import static com.snackgame.server.member.fixture.GroupFixture.홍천고등학�
 import com.snackgame.server.member.domain.Member;
 import com.snackgame.server.member.domain.Name;
 import com.snackgame.server.member.domain.SocialMember;
-import com.snackgame.server.member.domain.Status;
 import com.snackgame.server.support.fixture.FixtureSaver;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberFixture {
 
     public static Member 똥수() {
-        return new Member(1L, new Name("똥수"), new Status(), 홍천고등학교());
+        return new Member(1L, new Name("똥수"), 홍천고등학교());
     }
 
     public static Member 땡칠() {
-        return new Member(2L, new Name("땡칠"), new Status(), 우테코());
+        return new Member(2L, new Name("땡칠"), 우테코());
     }
 
     public static SocialMember 정환() {
-        return SocialMember.from(
-                new Member(3L, new Name("정환"), new Status(), null),
+        return new SocialMember(3L,
+                new Name("정환"), null,
                 "GOOGLE", "user123412341234"
         );
     }
 
     public static Member 유진() {
-        return new Member(4L, new Name("유진"), new Status(), 숭실대학교());
+        return new Member(4L, new Name("유진"), 숭실대학교());
     }
 
     public static Member 정언() {
-        return new Member(5L, new Name("정언"), new Status(), 숭실대학교());
+        return new Member(5L, new Name("정언"), 숭실대학교());
     }
 
     public static void saveAll() {


### PR DESCRIPTION
**커밋 수가 많지 않으니 [여기](https://github.com/snack-game/server/pull/109/commits/4fe7b1e7ab089bbba76fc6bd1544f00fccdb6d32)부터 커밋별로 보시는 것을 추천합니다**
<img width="366" alt="image" src="https://github.com/snack-game/server/assets/39221443/917975ba-6915-4f0b-9fd6-2626f89480f2">
`Next >` 를 눌러 넘길 수 있어용

## 주 변경 사항
### AS-IS
- 소셜 로그인 시 프로필 이미지를 일부 저장하였으나 사용하지 않았다.
### TO-BE
- 계정 생성시 기본 프로필 이미지가 할당된다.
  - <img src="https://snackgame.s3.ap-northeast-2.amazonaws.com/static/logo.png" width=50>
- 프로필 이미지를 원하는 이미지로 변경할 수 있다.

## 부가 변경 사항
### AS-IS
- '사용자 소셜 계정으로 통합'시 토큰이 변경되지 않는 이슈(쿠키 토큰 미대응)
- `Status` 객체를 외부에서 생성해 넣어주었다.

### TO-BE
- '소셜 계정으로 통합'시 새로운 유저로 쿠키 토큰을 재발급한다.
- Member 객체 내부에서 Status 객체를 생성하고, 재할당을 막아 외부에서 조작되지 않도록 개선한다.