### PR TITLE
fix: 개발 환경과 운영 환경 S3 credential 분리

### DIFF
--- a/src/main/java/com/snackgame/server/config/S3Config.java
+++ b/src/main/java/com/snackgame/server/config/S3Config.java
@@ -25,6 +25,7 @@ public class S3Config {
                 .build();
     }
 
+    @Profile("!production")
     @Bean
     public AmazonS3 amazonS3(
             @Value("${cloud.aws.credentials.access-key}")


### PR DESCRIPTION
## 관련 PR
- #109 

## 변경 사항
### AS-IS
운영 환경과 개발 환경에서 S3 설정을 다르게 하고자 함.
그러나 `@Profile`을 적절히 사용하지 못해서 중복된 Bean이 발생했음.

### TO-BE
프로덕션과 / 프로덕션이 아닌 상황으로 구분해 빈을 생성하도록 수정