### PR TITLE
refactor: 프로필 이미지 갱신 시기와 네이밍 방식을 개선한다

### DIFF
--- a/src/main/java/com/snackgame/server/common/file/S3FileUploader.kt
+++ b/src/main/java/com/snackgame/server/common/file/S3FileUploader.kt
@@ -39,6 +39,7 @@ class S3FileUploader(
     }
 
     private fun uniquePathOf(resource: Resource): String {
-        return "unhashed/${UUID.randomUUID()}-${resource.filename}"
+        val randomUUID = UUID.randomUUID().toString()
+        return "unhashed/${randomUUID.replace("-", "")}-${resource.hashCode()}"
     }
 }

--- a/src/main/java/com/snackgame/server/member/domain/Member.java
+++ b/src/main/java/com/snackgame/server/member/domain/Member.java
@@ -42,6 +42,11 @@ public class Member extends BaseEntity {
         this.name = name;
     }
 
+    public Member(Name name, ProfileImage profileImage) {
+        this.name = name;
+        this.profileImage = profileImage;
+    }
+
     public Member(Long id, Name name, Group group) {
         this.id = id;
         this.name = name;

--- a/src/main/java/com/snackgame/server/member/domain/ProfileImage.java
+++ b/src/main/java/com/snackgame/server/member/domain/ProfileImage.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class ProfileImage {
 
     private static final List<String> ALLOWED_SCHEMES = List.of("http", "https");
+    private static final int MAXIMUM_URL_LENGTH = 255;
 
     public static final ProfileImage EMPTY = new ProfileImage(
             "https://snackgame.s3.ap-northeast-2.amazonaws.com/static/logo.png");
@@ -24,7 +25,14 @@ public class ProfileImage {
 
     public ProfileImage(String url) {
         validate(url);
+        validateLengthOf(url);
         this.url = url;
+    }
+
+    private void validateLengthOf(String url) {
+        if (url.length() > MAXIMUM_URL_LENGTH) {
+            throw new InvalidProfileImageException();
+        }
     }
 
     private void validate(String url) {

--- a/src/main/java/com/snackgame/server/member/domain/SnackgameSocialMemberSaver.java
+++ b/src/main/java/com/snackgame/server/member/domain/SnackgameSocialMemberSaver.java
@@ -21,10 +21,10 @@ public class SnackgameSocialMemberSaver implements SocialMemberSaver<SocialMembe
         SocialMember member = members.findByProviderAndProvidedId(attributes.getProvider(), attributes.getId())
                 .orElseGet(() -> new SocialMember(
                         distinctNaming.from(new Name(attributes.getName())),
+                        new ProfileImage(attributes.getPictureUrl()),
                         attributes.getProvider(),
                         attributes.getId()
                 ));
-        member.changeProfileImageTo(new ProfileImage(attributes.getPictureUrl()));
         member.setAdditional(attributes.getEmail(), attributes.getNickname());
         return members.save(member);
     }

--- a/src/main/java/com/snackgame/server/member/domain/SocialMember.java
+++ b/src/main/java/com/snackgame/server/member/domain/SocialMember.java
@@ -15,8 +15,8 @@ public class SocialMember extends Member {
     private String provider;
     private String providedId;
 
-    public SocialMember(Name name, String provider, String providedId) {
-        super(name);
+    public SocialMember(Name name, ProfileImage profileImage, String provider, String providedId) {
+        super(name, profileImage);
         this.provider = provider;
         this.providedId = providedId;
     }

--- a/src/test/java/com/snackgame/server/common/file/S3FileUploaderTest.kt
+++ b/src/test/java/com/snackgame/server/common/file/S3FileUploaderTest.kt
@@ -1,0 +1,44 @@
+package com.snackgame.server.common.file
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class S3FileUploaderTest {
+
+    /*
+    UUID는 충돌할 확률이 극히 낮습니다.
+    거기에 일반적으로 충돌할 확률이 낮은 hashCode를 첨가하니, 더 확률이 희박해집니다.
+    그럼에도 충돌한다면 어떨까요?
+    그래도 프로필 이미지는 중요하지 않으므로 괜찮다고 생각합니다. 로또 사러 가야죠.
+     */
+
+    @Test
+    fun `UUID는 충돌할 확률이 극히 낮다`() {
+        assertThat(UUID.randomUUID()).isNotEqualTo(UUID.randomUUID())
+    }
+
+    @Nested
+    inner class `String의 hashCode는` {
+        @Test
+        fun `일반적으로 다르다`() {
+            assertThat("image1234".hashCode()).isNotEqualTo("image1235".hashCode())
+        }
+
+        @Test
+        fun `가끔 충돌할 수도 있다`() {
+            assertThat("S.ME".hashCode()).isEqualTo("RN.E".hashCode())
+        }
+    }
+
+    @Test
+    fun `UUID와 String의 hashCode를 합치면 충돌확률이 더더욱 낮다`() {
+        assertThat(generateUniqueId("imageA")).isNotEqualTo(generateUniqueId("imageB"))
+    }
+
+    private fun generateUniqueId(string: String): String {
+        val randomUUID = UUID.randomUUID().toString()
+        return "${randomUUID.replace("-", "")}-${string.hashCode()}"
+    }
+}

--- a/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
+++ b/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
@@ -6,6 +6,7 @@ import static com.snackgame.server.member.fixture.GroupFixture.홍천고등학�
 
 import com.snackgame.server.member.domain.Member;
 import com.snackgame.server.member.domain.Name;
+import com.snackgame.server.member.domain.ProfileImage;
 import com.snackgame.server.member.domain.SocialMember;
 import com.snackgame.server.support.fixture.FixtureSaver;
 


### PR DESCRIPTION
[커밋 별로 리뷰](https://github.com/snack-game/server/pull/115/commits/a39ca0dac13b34ce8c5c047c80e8420cb85b8cfd)하시는 걸 추천합니다!

## 변경 사항
### AS-IS
변경한 프로필 이미지가 소셜 로그인을 다시 했을 때 갱신되었다.
S3 업로드할 파일 이름을 생성하는 과정에 원본 파일의 이름이 포함되어, 최종 URL이 너무 길어지는 경우가 발생했다.

### TO-BE
소셜 로그인 시 소셜 이미지가 갱신되지 않도록 변경한다.
업로드할 파일 이름 지정 방식을 UUID와 `String.hashCode()`를 사용하도록 변경하였다.

----

매끄러운 협업을 위해 우선 머지합니다!