### PR TITLE
chore: Graceful Shutdown 적용

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -105,6 +105,6 @@ jobs:
         run: |
           PROCESS_ID="$(lsof -i:$BLUE_PORT -t)"
           if [ -n "$PROCESS_ID" ]; then
-            sudo kill -9 $PROCESS_ID
+            sudo kill -15 $PROCESS_ID
             echo "구동중인 애플리케이션을 종료했습니다. (pid : $PROCESS_ID)\n"
           fi

--- a/src/main/java/com/snackgame/server/test/TestController.java
+++ b/src/main/java/com/snackgame/server/test/TestController.java
@@ -1,0 +1,13 @@
+package com.snackgame.server.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    @GetMapping("/test")
+    public void test() throws InterruptedException {
+        Thread.sleep(15000);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
   web:
     resources:
       add-mappings: false
+  lifecycle:
+    timeout-per-shutdown-phase: 10s
 springdoc:
   api-docs:
     path: /docs
@@ -19,3 +21,6 @@ springdoc:
   cache:
     disabled: true
   override-with-generic-response: false
+
+server:
+  shutdown: graceful


### PR DESCRIPTION
## 관련 이슈
- #116 
- resolves: #116 

## 변경 사항
### AS-IS
오래된 버전의 애플리케이션을 종료할때 진행 중인 요청이 존재하면 그 요청을 처리하지 않고 강제 종료를 하였다.

### TO-BE
Graceful Shutdown을 적용하여 새로운 요청은 차단하고 진행 중인 요청은 완료 후 정상 종료를 하도록 변경하였다.