### PR TITLE
feat: 게임 종료시 점수와 백분위를 알 수 있다

### DIFF
--- a/src/main/java/com/snackgame/server/applegame/AppleGameService.java
+++ b/src/main/java/com/snackgame/server/applegame/AppleGameService.java
@@ -7,6 +7,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.snackgame.server.applegame.controller.dto.GameResultResponse;
 import com.snackgame.server.applegame.controller.dto.RangeRequest;
 import com.snackgame.server.applegame.domain.game.AppleGame;
 import com.snackgame.server.applegame.domain.game.AppleGames;
@@ -49,11 +50,17 @@ public class AppleGameService {
         return game;
     }
 
-    public void finish(Long memberId, Long sessionId) {
+    public GameResultResponse finish(Long memberId, Long sessionId) {
         AppleGame game = appleGames.getBy(memberId, sessionId);
         game.finish();
+        eventPublisher.publishEvent(new GameEndEvent(game));
+
         Member member = memberRepository.getById(memberId);
         member.getStatus().addExp(game.getScore());
-        eventPublisher.publishEvent(new GameEndEvent(game));
+
+        return new GameResultResponse(
+                game.getScore(),
+                appleGames.ratePercentileOf(sessionId).percentage()
+        );
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/controller/dto/GameResultResponse.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/dto/GameResultResponse.java
@@ -1,0 +1,15 @@
+package com.snackgame.server.applegame.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GameResultResponse {
+
+    @Schema(example = "117")
+    private final int score;
+    @Schema(example = "5")
+    private final int percentile;
+}

--- a/src/main/java/com/snackgame/server/applegame/domain/game/Percentile.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/Percentile.java
@@ -1,0 +1,24 @@
+package com.snackgame.server.applegame.domain.game;
+
+import com.snackgame.server.applegame.exception.InaccuratePercentileException;
+
+public class Percentile {
+
+    private final double percentile;
+
+    public Percentile(double percentile) {
+        validateRangeOf(percentile);
+        this.percentile = percentile;
+    }
+
+    private void validateRangeOf(double percentile) {
+        if (percentile < 0 || 1 < percentile) {
+            throw new InaccuratePercentileException(percentile);
+        }
+    }
+
+    public int percentage() {
+        double percentageWise = Math.floor(percentile * 100);
+        return (int)percentageWise;
+    }
+}

--- a/src/main/java/com/snackgame/server/applegame/exception/AppleGameException.java
+++ b/src/main/java/com/snackgame/server/applegame/exception/AppleGameException.java
@@ -1,10 +1,15 @@
 package com.snackgame.server.applegame.exception;
 
 import com.snackgame.server.common.exception.BusinessException;
+import com.snackgame.server.common.exception.Kind;
 
 public abstract class AppleGameException extends BusinessException {
 
     public AppleGameException(String message) {
         super(message);
+    }
+
+    public AppleGameException(Kind kind, String message) {
+        super(kind, message);
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/exception/InaccuratePercentileException.java
+++ b/src/main/java/com/snackgame/server/applegame/exception/InaccuratePercentileException.java
@@ -1,0 +1,10 @@
+package com.snackgame.server.applegame.exception;
+
+import com.snackgame.server.common.exception.Kind;
+
+public class InaccuratePercentileException extends AppleGameException {
+
+    public InaccuratePercentileException(double percentile) {
+        super(Kind.INTERNAL_SERVER_ERROR, "백분위 계산이 잘못되었습니다: " + percentile);
+    }
+}

--- a/src/main/java/com/snackgame/server/applegame/exception/SessionNotFinishedException.java
+++ b/src/main/java/com/snackgame/server/applegame/exception/SessionNotFinishedException.java
@@ -1,0 +1,10 @@
+package com.snackgame.server.applegame.exception;
+
+import com.snackgame.server.common.exception.Kind;
+
+public class SessionNotFinishedException extends AppleGameException {
+
+    public SessionNotFinishedException() {
+        super(Kind.INTERNAL_SERVER_ERROR, "세션이 아직 종료되지 않았습니다");
+    }
+}

--- a/src/main/java/com/snackgame/server/common/exception/BusinessException.java
+++ b/src/main/java/com/snackgame/server/common/exception/BusinessException.java
@@ -2,7 +2,18 @@ package com.snackgame.server.common.exception;
 
 public abstract class BusinessException extends RuntimeException {
 
+    private final Kind kind;
+
     public BusinessException(String message) {
+        this(Kind.BAD_REQUEST, message);
+    }
+
+    public BusinessException(Kind kind, String message) {
         super(message);
+        this.kind = kind;
+    }
+
+    public Kind getKind() {
+        return kind;
     }
 }

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -51,11 +52,15 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ExceptionResponse handleBusinessException(BusinessException exception) {
+    public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException exception) {
         log.debug(exception.getMessage(), exception);
 
-        return ExceptionResponse.from(exception);
+        Kind kind = exception.getKind();
+        var responseEntity = ResponseEntity.status(kind.getHttpStatus());
+        if (kind.needsMessageToBeHidden()) {
+            return responseEntity.body(ExceptionResponse.withDefaultMessage());
+        }
+        return responseEntity.body(new ExceptionResponse(exception.getMessage()));
     }
 
     @ExceptionHandler

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -53,13 +53,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException exception) {
-        log.debug(exception.getMessage(), exception);
-
         Kind kind = exception.getKind();
         var responseEntity = ResponseEntity.status(kind.getHttpStatus());
         if (kind.needsMessageToBeHidden()) {
+            log.error(exception.getMessage(), exception);
+            eventPublisher.publishEvent(new ExceptionalEvent(
+                    exception.getClass().getSimpleName(),
+                    exception.getMessage()
+            ));
             return responseEntity.body(ExceptionResponse.withDefaultMessage());
         }
+        log.debug(exception.getMessage(), exception);
         return responseEntity.body(new ExceptionResponse(exception.getMessage()));
     }
 

--- a/src/main/java/com/snackgame/server/common/exception/Kind.java
+++ b/src/main/java/com/snackgame/server/common/exception/Kind.java
@@ -1,0 +1,25 @@
+package com.snackgame.server.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum Kind {
+
+    INTERNAL_SERVER_ERROR(true, HttpStatus.INTERNAL_SERVER_ERROR),
+    BAD_REQUEST(true, HttpStatus.BAD_REQUEST);
+
+    private final boolean needsMessageToBeHidden;
+    private final HttpStatus httpStatus;
+
+    Kind(boolean needsMessageToBeHidden, HttpStatus httpStatus) {
+        this.needsMessageToBeHidden = needsMessageToBeHidden;
+        this.httpStatus = httpStatus;
+    }
+
+    public boolean needsMessageToBeHidden() {
+        return needsMessageToBeHidden;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/snackgame/server/common/exception/dto/ExceptionResponse.java
+++ b/src/main/java/com/snackgame/server/common/exception/dto/ExceptionResponse.java
@@ -28,10 +28,6 @@ public class ExceptionResponse {
         return new ExceptionResponse(DEFAULT_MESSAGE);
     }
 
-    public static ExceptionResponse from(Exception exception) {
-        return new ExceptionResponse(exception.getMessage());
-    }
-
     public String getAction() {
         return action;
     }

--- a/src/test/java/com/snackgame/server/applegame/AppleGameServiceTest.java
+++ b/src/test/java/com/snackgame/server/applegame/AppleGameServiceTest.java
@@ -121,6 +121,29 @@ class AppleGameServiceTest {
     }
 
     @Test
+    void 게임을_끝낼_때_점수와_백분율을_알_수_있다() {
+        var game = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 정환().getId()));
+        appleGameService.placeMoves(정환().getId(), game.getSessionId(), List.of(new RangeRequest(
+                new CoordinateRequest(0, 1),
+                new CoordinateRequest(1, 3)
+        )));
+        appleGameService.finish(정환().getId(), game.getSessionId());
+
+        var otherGame = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId()));
+        appleGameService.finish(땡칠().getId(), otherGame.getSessionId());
+
+        var gameWithMidRangedScore = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId()));
+        appleGameService.placeMoves(땡칠().getId(), gameWithMidRangedScore.getSessionId(), List.of(new RangeRequest(
+                new CoordinateRequest(0, 0),
+                new CoordinateRequest(1, 0)
+        )));
+        var result = appleGameService.finish(땡칠().getId(), gameWithMidRangedScore.getSessionId());
+
+        assertThat(result.getScore()).isEqualTo(2);
+        assertThat(result.getPercentile()).isEqualTo(50);
+    }
+
+    @Test
     void 게임이_끝날때_게임_점수만큼_경험치를_부여한다() {
         var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 정환().getId());
         appleGames.save(game);

--- a/src/test/java/com/snackgame/server/applegame/domain/game/PercentileTest.java
+++ b/src/test/java/com/snackgame/server/applegame/domain/game/PercentileTest.java
@@ -1,0 +1,40 @@
+package com.snackgame.server.applegame.domain.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.snackgame.server.applegame.exception.InaccuratePercentileException;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PercentileTest {
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.0, 0.1, 0.9999, 1.0})
+    void 백분위는_0과_1사이의_소수다(double percentile) {
+        assertThatNoException()
+                .isThrownBy(() -> new Percentile(percentile));
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {-0.001, 1.001})
+    void 백분위가_0과_1사이여야한다(double percentile) {
+        assertThatThrownBy(() -> new Percentile(percentile))
+                .isInstanceOf(InaccuratePercentileException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0.0, 0", "0.4949, 49", "0.495, 49", "1.0, 100"})
+    void 백분위의_정수_이하를_버려_백분율을_구한다(double percentile, int expectedPercentage) {
+        int percentage = new Percentile(percentile).percentage();
+
+        assertThat(percentage).isEqualTo(expectedPercentage);
+    }
+}


### PR DESCRIPTION
## 변경 사항
### AS-IS
게임 완료 시 응답이 없었으며, 클라이언트가 아는 정보로 처리하였다.
비즈니스 예외의 상태 코드를 제어할 수 없었다.
### TO-BE
게임 완료 시 점수 및 백분위를 퍼센트로 함께 반환한다.
비즈니스 예외의 '종류'를 통해 상태 코드 및 로그 여부를 제어할 수 있다.