### PR TITLE
feat: 게임 종료시 점수와 백분위를 알 수 있다

### DIFF
--- a/src/main/java/com/snackgame/server/applegame/AppleGameService.java
+++ b/src/main/java/com/snackgame/server/applegame/AppleGameService.java
@@ -7,6 +7,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.snackgame.server.applegame.controller.dto.GameResultResponse;
 import com.snackgame.server.applegame.controller.dto.RangeRequest;
 import com.snackgame.server.applegame.domain.game.AppleGame;
 import com.snackgame.server.applegame.domain.game.AppleGames;
@@ -49,11 +50,17 @@ public class AppleGameService {
         return game;
     }
 
-    public void finish(Long memberId, Long sessionId) {
+    public GameResultResponse finish(Long memberId, Long sessionId) {
         AppleGame game = appleGames.getBy(memberId, sessionId);
         game.finish();
+        eventPublisher.publishEvent(new GameEndEvent(game));
+
         Member member = memberRepository.getById(memberId);
         member.getStatus().addExp(game.getScore());
-        eventPublisher.publishEvent(new GameEndEvent(game));
+
+        return new GameResultResponse(
+                game.getScore(),
+                appleGames.ratePercentileOf(sessionId).percentage()
+        );
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.snackgame.server.applegame.AppleGameService;
 import com.snackgame.server.applegame.controller.dto.AppleGameResponseV2;
+import com.snackgame.server.applegame.controller.dto.GameResultResponse;
 import com.snackgame.server.applegame.controller.dto.RangeRequest;
 import com.snackgame.server.applegame.domain.game.AppleGame;
 import com.snackgame.server.auth.token.support.Authenticated;
@@ -59,7 +60,7 @@ public class AppleGameControllerV2 implements AppleGameControllerV2Docs {
 
     @Override
     @PutMapping("/sessions/{sessionId}/end")
-    public void finish(@Authenticated Member member, @PathVariable Long sessionId) {
-        appleGameService.finish(member.getId(), sessionId);
+    public GameResultResponse finish(@Authenticated Member member, @PathVariable Long sessionId) {
+        return appleGameService.finish(member.getId(), sessionId);
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Docs.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Docs.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.snackgame.server.applegame.controller.dto.AppleGameResponseV2;
+import com.snackgame.server.applegame.controller.dto.GameResultResponse;
 import com.snackgame.server.applegame.controller.dto.RangeRequest;
 import com.snackgame.server.member.domain.Member;
 
@@ -14,7 +15,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "🍎 사과 게임")
 public interface AppleGameControllerV2Docs {
 
     @Operation(summary = "게임 세션 시작", description = "1번 게임(사과게임) 세션을 시작한다")
@@ -43,9 +46,9 @@ public interface AppleGameControllerV2Docs {
             @RequestBody List<RangeRequest> ranges
     );
 
-    @Operation(summary = "게임판 초기화", description = "지정한 세션의 게임판을 초기화한다. 황금사과와는 별도의 기능이다.")
+    @Operation(summary = "게임 재시작", description = "게임을 재시작한다. 게임판과 시간이 초기화된다.")
     AppleGameResponseV2 restart(Member member, @PathVariable Long sessionId);
 
-    @Operation(summary = "게임 세션 종료", description = "현재 세션의 종료를 알린다")
-    void finish(Member member, @PathVariable Long sessionId);
+    @Operation(summary = "게임 세션 종료", description = "게임 세션을 종료한다. 응답에는 기록된 점수와 전체 게임에서의 백분위가 포함된다")
+    GameResultResponse finish(Member member, @PathVariable Long sessionId);
 }

--- a/src/main/java/com/snackgame/server/applegame/controller/dto/AppleResponse.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/dto/AppleResponse.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class AppleResponse {
 
     private final int number;
-    private final boolean isGolden;
+    private final boolean golden;
 
     public static List<List<AppleResponse>> of(List<List<Apple>> apples) {
         return apples.stream()

--- a/src/main/java/com/snackgame/server/applegame/controller/dto/GameResultResponse.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/dto/GameResultResponse.java
@@ -1,0 +1,15 @@
+package com.snackgame.server.applegame.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GameResultResponse {
+
+    @Schema(example = "117")
+    private final int score;
+    @Schema(example = "5")
+    private final int percentile;
+}

--- a/src/main/java/com/snackgame/server/applegame/domain/game/Percentile.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/Percentile.java
@@ -1,0 +1,24 @@
+package com.snackgame.server.applegame.domain.game;
+
+import com.snackgame.server.applegame.exception.InaccuratePercentileException;
+
+public class Percentile {
+
+    private final double percentile;
+
+    public Percentile(double percentile) {
+        validateRangeOf(percentile);
+        this.percentile = percentile;
+    }
+
+    private void validateRangeOf(double percentile) {
+        if (percentile < 0 || 1 < percentile) {
+            throw new InaccuratePercentileException(percentile);
+        }
+    }
+
+    public int percentage() {
+        double percentageWise = Math.floor(percentile * 100);
+        return (int)percentageWise;
+    }
+}

--- a/src/main/java/com/snackgame/server/applegame/exception/AppleGameException.java
+++ b/src/main/java/com/snackgame/server/applegame/exception/AppleGameException.java
@@ -1,10 +1,15 @@
 package com.snackgame.server.applegame.exception;
 
 import com.snackgame.server.common.exception.BusinessException;
+import com.snackgame.server.common.exception.Kind;
 
 public abstract class AppleGameException extends BusinessException {
 
     public AppleGameException(String message) {
         super(message);
+    }
+
+    public AppleGameException(Kind kind, String message) {
+        super(kind, message);
     }
 }

--- a/src/main/java/com/snackgame/server/applegame/exception/InaccuratePercentileException.java
+++ b/src/main/java/com/snackgame/server/applegame/exception/InaccuratePercentileException.java
@@ -1,0 +1,10 @@
+package com.snackgame.server.applegame.exception;
+
+import com.snackgame.server.common.exception.Kind;
+
+public class InaccuratePercentileException extends AppleGameException {
+
+    public InaccuratePercentileException(double percentile) {
+        super(Kind.INTERNAL_SERVER_ERROR, "백분위 계산이 잘못되었습니다: " + percentile);
+    }
+}

--- a/src/main/java/com/snackgame/server/applegame/exception/SessionNotFinishedException.java
+++ b/src/main/java/com/snackgame/server/applegame/exception/SessionNotFinishedException.java
@@ -1,0 +1,10 @@
+package com.snackgame.server.applegame.exception;
+
+import com.snackgame.server.common.exception.Kind;
+
+public class SessionNotFinishedException extends AppleGameException {
+
+    public SessionNotFinishedException() {
+        super(Kind.INTERNAL_SERVER_ERROR, "세션이 아직 종료되지 않았습니다");
+    }
+}

--- a/src/main/java/com/snackgame/server/common/exception/BusinessException.java
+++ b/src/main/java/com/snackgame/server/common/exception/BusinessException.java
@@ -2,7 +2,18 @@ package com.snackgame.server.common.exception;
 
 public abstract class BusinessException extends RuntimeException {
 
+    private final Kind kind;
+
     public BusinessException(String message) {
+        this(Kind.BAD_REQUEST, message);
+    }
+
+    public BusinessException(Kind kind, String message) {
         super(message);
+        this.kind = kind;
+    }
+
+    public Kind getKind() {
+        return kind;
     }
 }

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -51,11 +52,15 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ExceptionResponse handleBusinessException(BusinessException exception) {
+    public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException exception) {
         log.debug(exception.getMessage(), exception);
 
-        return ExceptionResponse.from(exception);
+        Kind kind = exception.getKind();
+        var responseEntity = ResponseEntity.status(kind.getHttpStatus());
+        if (kind.needsMessageToBeHidden()) {
+            return responseEntity.body(ExceptionResponse.withDefaultMessage());
+        }
+        return responseEntity.body(new ExceptionResponse(exception.getMessage()));
     }
 
     @ExceptionHandler

--- a/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snackgame/server/common/exception/GlobalExceptionHandler.java
@@ -53,13 +53,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ExceptionResponse> handleBusinessException(BusinessException exception) {
-        log.debug(exception.getMessage(), exception);
-
         Kind kind = exception.getKind();
         var responseEntity = ResponseEntity.status(kind.getHttpStatus());
         if (kind.needsMessageToBeHidden()) {
+            log.error(exception.getMessage(), exception);
+            eventPublisher.publishEvent(new ExceptionalEvent(
+                    exception.getClass().getSimpleName(),
+                    exception.getMessage()
+            ));
             return responseEntity.body(ExceptionResponse.withDefaultMessage());
         }
+        log.debug(exception.getMessage(), exception);
         return responseEntity.body(new ExceptionResponse(exception.getMessage()));
     }
 

--- a/src/main/java/com/snackgame/server/common/exception/Kind.java
+++ b/src/main/java/com/snackgame/server/common/exception/Kind.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum Kind {
 
     INTERNAL_SERVER_ERROR(true, HttpStatus.INTERNAL_SERVER_ERROR),
-    BAD_REQUEST(true, HttpStatus.BAD_REQUEST);
+    BAD_REQUEST(false, HttpStatus.BAD_REQUEST);
 
     private final boolean needsMessageToBeHidden;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/snackgame/server/common/exception/Kind.java
+++ b/src/main/java/com/snackgame/server/common/exception/Kind.java
@@ -1,0 +1,25 @@
+package com.snackgame.server.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum Kind {
+
+    INTERNAL_SERVER_ERROR(true, HttpStatus.INTERNAL_SERVER_ERROR),
+    BAD_REQUEST(true, HttpStatus.BAD_REQUEST);
+
+    private final boolean needsMessageToBeHidden;
+    private final HttpStatus httpStatus;
+
+    Kind(boolean needsMessageToBeHidden, HttpStatus httpStatus) {
+        this.needsMessageToBeHidden = needsMessageToBeHidden;
+        this.httpStatus = httpStatus;
+    }
+
+    public boolean needsMessageToBeHidden() {
+        return needsMessageToBeHidden;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/snackgame/server/common/exception/dto/ExceptionResponse.java
+++ b/src/main/java/com/snackgame/server/common/exception/dto/ExceptionResponse.java
@@ -28,10 +28,6 @@ public class ExceptionResponse {
         return new ExceptionResponse(DEFAULT_MESSAGE);
     }
 
-    public static ExceptionResponse from(Exception exception) {
-        return new ExceptionResponse(exception.getMessage());
-    }
-
     public String getAction() {
         return action;
     }

--- a/src/test/java/com/snackgame/server/applegame/AppleGameServiceTest.java
+++ b/src/test/java/com/snackgame/server/applegame/AppleGameServiceTest.java
@@ -121,6 +121,29 @@ class AppleGameServiceTest {
     }
 
     @Test
+    void 게임을_끝낼_때_점수와_백분율을_알_수_있다() {
+        var game = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 정환().getId()));
+        appleGameService.placeMoves(정환().getId(), game.getSessionId(), List.of(new RangeRequest(
+                new CoordinateRequest(0, 1),
+                new CoordinateRequest(1, 3)
+        )));
+        appleGameService.finish(정환().getId(), game.getSessionId());
+
+        var otherGame = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId()));
+        appleGameService.finish(땡칠().getId(), otherGame.getSessionId());
+
+        var gameWithMidRangedScore = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId()));
+        appleGameService.placeMoves(땡칠().getId(), gameWithMidRangedScore.getSessionId(), List.of(new RangeRequest(
+                new CoordinateRequest(0, 0),
+                new CoordinateRequest(1, 0)
+        )));
+        var result = appleGameService.finish(땡칠().getId(), gameWithMidRangedScore.getSessionId());
+
+        assertThat(result.getScore()).isEqualTo(2);
+        assertThat(result.getPercentile()).isEqualTo(50);
+    }
+
+    @Test
     void 게임이_끝날때_게임_점수만큼_경험치를_부여한다() {
         var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 정환().getId());
         appleGames.save(game);

--- a/src/test/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Test.java
+++ b/src/test/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Test.java
@@ -1,0 +1,214 @@
+package com.snackgame.server.applegame.controller;
+
+import static com.snackgame.server.member.fixture.MemberFixture.땡칠;
+import static com.snackgame.server.member.fixture.MemberFixture.땡칠_인증정보;
+import static com.snackgame.server.member.fixture.MemberFixture.똥수;
+import static com.snackgame.server.member.fixture.MemberFixture.똥수_인증정보;
+import static com.snackgame.server.member.fixture.MemberFixture.정환;
+import static com.snackgame.server.support.restassured.RestAssuredUtil.givenAuthentication;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.snackgame.server.applegame.controller.dto.AppleGameResponseV2;
+import com.snackgame.server.applegame.controller.dto.CoordinateRequest;
+import com.snackgame.server.applegame.controller.dto.GameResultResponse;
+import com.snackgame.server.applegame.controller.dto.RangeRequest;
+import com.snackgame.server.applegame.domain.Coordinate;
+import com.snackgame.server.applegame.domain.Range;
+import com.snackgame.server.applegame.domain.game.AppleGame;
+import com.snackgame.server.applegame.domain.game.AppleGames;
+import com.snackgame.server.applegame.fixture.TestFixture;
+import com.snackgame.server.fixture.SeasonFixture;
+import com.snackgame.server.member.controller.dto.MemberDetailsResponse;
+import com.snackgame.server.member.fixture.MemberFixture;
+import com.snackgame.server.support.restassured.RestAssuredTest;
+
+import io.restassured.http.ContentType;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@RestAssuredTest
+class AppleGameControllerV2Test {
+
+    @Autowired
+    AppleGames appleGames;
+
+    @BeforeEach
+    void setUp() {
+        MemberFixture.saveAll();
+        SeasonFixture.saveAll();
+    }
+
+    @Test
+    void 게임을_시작한다() {
+        var response = givenAuthentication(땡칠_인증정보())
+                .when().post("/v2/games/1")
+                .then().statusCode(OK.value())
+                .extract().as(AppleGameResponseV2.class);
+
+        assertThat(response.getSessionId()).isNotNull();
+        assertThat(response.getApples()).hasSize(AppleGame.DEFAULT_HEIGHT);
+        assertThat(response.getApples().get(0)).hasSize(AppleGame.DEFAULT_WIDTH);
+    }
+
+    @Test
+    void 게임을_조작한다() {
+        var game = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId()));
+        List<RangeRequest> rangeRequests = List.of(
+                new RangeRequest(
+                        new CoordinateRequest(0, 1),
+                        new CoordinateRequest(1, 3)
+                ),
+                new RangeRequest(
+                        new CoordinateRequest(0, 0),
+                        new CoordinateRequest(1, 0)
+                )
+        );
+
+        givenAuthentication(땡칠_인증정보())
+                .contentType(ContentType.JSON)
+                .body(rangeRequests)
+                .when().put("/v2/sessions/{sessionId}/moves", game.getSessionId())
+                .then().statusCode(OK.value());
+    }
+
+    @Test
+    void 황금사과를_제거하면_초기화된_판을_반환한다() {
+        var game = appleGames.save(new AppleGame(TestFixture.TWO_BY_TWO_WITH_GOLDEN_APPLE(), 땡칠().getId()));
+        List<RangeRequest> rangeRequests = List.of(new RangeRequest(
+                new CoordinateRequest(0, 0),
+                new CoordinateRequest(1, 0))
+        );
+
+        givenAuthentication(땡칠_인증정보())
+                .contentType(ContentType.JSON)
+                .body(rangeRequests)
+                .when().put("/v2/sessions/{sessionId}/moves", game.getSessionId())
+                .then().statusCode(CREATED.value())
+                .extract().as(AppleGameResponseV2.class);
+    }
+
+    @Test
+    void 황금사과를_제거하지_않으면_판을_반환하지_않는다() {
+        var game = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId()));
+        var rangeRequests = List.of(new RangeRequest(
+                new CoordinateRequest(0, 0),
+                new CoordinateRequest(1, 0))
+        );
+
+        givenAuthentication(땡칠_인증정보())
+                .contentType(ContentType.JSON)
+                .body(rangeRequests)
+                .when().put("/v2/sessions/{sessionId}/moves", game.getSessionId())
+                .then().statusCode(OK.value())
+                .body(emptyOrNullString());
+    }
+
+    @Test
+    void 게임을_재시작한다() {
+        var started = givenAuthentication(땡칠_인증정보())
+                .when().post("/v2/games/1")
+                .then().statusCode(OK.value())
+                .extract().as(AppleGameResponseV2.class);
+        givenAuthentication(땡칠_인증정보())
+                .contentType(ContentType.JSON)
+                .body(List.of(new RangeRequest(
+                        new CoordinateRequest(0, 0),
+                        new CoordinateRequest(1, 0))
+                ))
+                .when().put("/v2/sessions/{sessionId}/moves", started.getSessionId());
+
+        var restarted = givenAuthentication(땡칠_인증정보())
+                .when().delete("/v2/sessions/{sessionId}/board", started.getSessionId())
+                .then().statusCode(OK.value())
+                .extract().as(AppleGameResponseV2.class);
+
+        assertThat(started.getSessionId()).isEqualTo(restarted.getSessionId());
+        assertThat(restarted.getScore()).isZero();
+        assertThat(started.getApples())
+                .usingRecursiveComparison()
+                .isNotEqualTo(restarted.getApples());
+    }
+
+    @Test
+    void 게임을_끝낸다() {
+        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 똥수().getId());
+        game.removeApplesIn(new Range(
+                new Coordinate(0, 1),
+                new Coordinate(1, 3))
+        );
+        appleGames.save(game);
+
+        givenAuthentication(똥수_인증정보())
+                .when().put("/v2/sessions/{sessionId}/end", game.getSessionId())
+                .then().log().all()
+                .statusCode(OK.value())
+                .extract().as(GameResultResponse.class);
+    }
+
+    @Test
+    void 게임을_끝낼_때_점수와_백분율을_알_수_있다() {
+        {
+            var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 정환().getId());
+            game.removeApplesIn(new Range(
+                    new Coordinate(0, 1),
+                    new Coordinate(1, 3))
+            );
+            game.finish();
+            appleGames.save(game);
+        }
+        {
+            var otherGame = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId());
+            otherGame.finish();
+            appleGames.save(otherGame);
+        }
+
+        var gameWithMidRangedScore = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId());
+        gameWithMidRangedScore.removeApplesIn(new Range(
+                new Coordinate(0, 0),
+                new Coordinate(1, 0))
+        );
+        appleGames.save(gameWithMidRangedScore);
+
+        var result = givenAuthentication(땡칠_인증정보())
+                .when().put("/v2/sessions/{sessionId}/end", gameWithMidRangedScore.getSessionId())
+                .then()
+                .statusCode(OK.value())
+                .extract().as(GameResultResponse.class);
+
+        assertThat(result.getScore()).isEqualTo(2);
+        assertThat(result.getPercentile()).isEqualTo(50);
+    }
+
+    @Test
+    void 게임이_끝날때_게임_점수만큼_경험치를_부여한다() {
+        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 똥수().getId());
+        game.removeApplesIn(new Range(
+                new Coordinate(0, 1),
+                new Coordinate(1, 3))
+        );
+        appleGames.save(game);
+
+        givenAuthentication(똥수_인증정보())
+                .when().put("/v2/sessions/{sessionId}/end", game.getSessionId())
+                .then().statusCode(OK.value());
+
+        var member = givenAuthentication(똥수_인증정보())
+                .when().get("/members/me")
+                .then()
+                .statusCode(OK.value())
+                .extract().as(MemberDetailsResponse.class);
+
+        assertThat(member.getStatus().getExp()).isEqualTo(4);
+    }
+}

--- a/src/test/java/com/snackgame/server/applegame/domain/game/AppleGameTest.java
+++ b/src/test/java/com/snackgame/server/applegame/domain/game/AppleGameTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import com.snackgame.server.applegame.domain.Coordinate;
 import com.snackgame.server.applegame.domain.Range;
+import com.snackgame.server.applegame.exception.AppleNotRemovableException;
 import com.snackgame.server.applegame.exception.GameSessionExpiredException;
 import com.snackgame.server.applegame.fixture.TestFixture;
 
@@ -31,7 +32,7 @@ class AppleGameTest {
     }
 
     @Test
-    void 초기화한다() {
+    void 재시작한다() {
         var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId());
         var range = new Range(
                 new Coordinate(0, 1),
@@ -59,6 +60,20 @@ class AppleGameTest {
         game.removeApplesIn(range);
 
         assertThat(game.getScore()).isEqualTo(4);
+    }
+
+    @Test
+    void 이미_제거된_위치의_사과들을_제거하면_예외가_발생한다() {
+        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId());
+        game.removeApplesIn(new Range(
+                new Coordinate(0, 1),
+                new Coordinate(1, 3)
+        ));
+
+        assertThatThrownBy(() -> game.removeApplesIn(new Range(
+                new Coordinate(0, 1),
+                new Coordinate(1, 3)
+        ))).isInstanceOf(AppleNotRemovableException.class);
     }
 
     @Test

--- a/src/test/java/com/snackgame/server/applegame/domain/game/PercentileTest.java
+++ b/src/test/java/com/snackgame/server/applegame/domain/game/PercentileTest.java
@@ -1,0 +1,40 @@
+package com.snackgame.server.applegame.domain.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.snackgame.server.applegame.exception.InaccuratePercentileException;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PercentileTest {
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.0, 0.1, 0.9999, 1.0})
+    void 백분위는_0과_1사이의_소수다(double percentile) {
+        assertThatNoException()
+                .isThrownBy(() -> new Percentile(percentile));
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {-0.001, 1.001})
+    void 백분위가_0과_1사이여야한다(double percentile) {
+        assertThatThrownBy(() -> new Percentile(percentile))
+                .isInstanceOf(InaccuratePercentileException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0.0, 0", "0.4949, 49", "0.495, 49", "1.0, 100"})
+    void 백분위의_정수_이하를_버려_백분율을_구한다(double percentile, int expectedPercentage) {
+        int percentage = new Percentile(percentile).percentage();
+
+        assertThat(percentage).isEqualTo(expectedPercentage);
+    }
+}

--- a/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
+++ b/src/test/java/com/snackgame/server/member/fixture/MemberFixture.java
@@ -4,9 +4,9 @@ import static com.snackgame.server.member.fixture.GroupFixture.숭실대학교;
 import static com.snackgame.server.member.fixture.GroupFixture.우테코;
 import static com.snackgame.server.member.fixture.GroupFixture.홍천고등학교;
 
+import com.snackgame.server.member.controller.dto.NameRequest;
 import com.snackgame.server.member.domain.Member;
 import com.snackgame.server.member.domain.Name;
-import com.snackgame.server.member.domain.ProfileImage;
 import com.snackgame.server.member.domain.SocialMember;
 import com.snackgame.server.support.fixture.FixtureSaver;
 
@@ -17,8 +17,16 @@ public class MemberFixture {
         return new Member(1L, new Name("똥수"), 홍천고등학교());
     }
 
+    public static NameRequest 똥수_인증정보() {
+        return new NameRequest(똥수().getNameAsString());
+    }
+
     public static Member 땡칠() {
         return new Member(2L, new Name("땡칠"), 우테코());
+    }
+
+    public static NameRequest 땡칠_인증정보() {
+        return new NameRequest(땡칠().getNameAsString());
     }
 
     public static SocialMember 정환() {

--- a/src/test/java/com/snackgame/server/support/restassured/RestAssuredUtil.java
+++ b/src/test/java/com/snackgame/server/support/restassured/RestAssuredUtil.java
@@ -1,0 +1,20 @@
+package com.snackgame.server.support.restassured;
+
+import com.snackgame.server.member.controller.dto.NameRequest;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+
+public class RestAssuredUtil {
+
+    public static RequestSpecification givenAuthentication(NameRequest nameRequest) {
+        var cookies = RestAssured.given()
+                .body(nameRequest)
+                .contentType(ContentType.JSON)
+                .when().post("/tokens")
+                .then().extract().detailedCookies();
+
+        return RestAssured.given().cookies(cookies);
+    }
+}


### PR DESCRIPTION
## 변경 사항
### AS-IS
- 게임 완료 시 응답이 없었으며, 클라이언트가 아는 정보로 처리하였다.
- 비즈니스 예외의 상태 코드를 제어할 수 없었다.
- '이미 제거된 사과를 다시 제거하는 동작'에 대한 테스트가 없었다.

### TO-BE
- 게임 완료 시 점수 및 백분위를 퍼센트로 함께 반환한다.
  - 관련 인수 테스트를 추가 작성하였다.
- 비즈니스 예외의 '종류'를 통해 상태 코드 및 로그 여부를 제어할 수 있다.
- '이미 제거된 사과를 다시 제거하면 예외가 발생하는지?'에 대한 테스트를 추가하였다.