### PR TITLE
refactor: AppleGame의 종료시간을 지정해두도록 추가한다

### DIFF
--- a/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
@@ -3,6 +3,7 @@ package com.snackgame.server.applegame.domain.game;
 import static java.time.LocalDateTime.now;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -39,16 +40,19 @@ public class AppleGame extends BaseEntity {
     private Board board;
     private int score = 0;
     private boolean isFinished = false;
+    private LocalDateTime finishedAt;
 
     public AppleGame(Board board, Long ownerId) {
         this.board = board;
         this.ownerId = ownerId;
+        this.finishedAt = willFinishAt();
     }
 
-    public AppleGame(Board board, Long ownerId, LocalDateTime createdAt) {
+    public AppleGame(Board board, Long ownerId, LocalDateTime createdAt, LocalDateTime finishedAt) {
         this.board = board;
         this.ownerId = ownerId;
         this.createdAt = createdAt;
+        this.finishedAt = finishedAt;
     }
 
     public static AppleGame ofRandomized(Long ownerId) {
@@ -60,6 +64,7 @@ public class AppleGame extends BaseEntity {
         this.board = board.reset();
         this.score = 0;
         this.createdAt = now();
+        this.finishedAt = willFinishAt();
     }
 
     public void removeApplesIn(Range range) {
@@ -73,6 +78,7 @@ public class AppleGame extends BaseEntity {
 
     public void finish() {
         validateOngoing();
+        this.finishedAt = now();
         this.isFinished = true;
     }
 
@@ -83,7 +89,11 @@ public class AppleGame extends BaseEntity {
     }
 
     public boolean isFinished() {
-        return isFinished || now().isAfter(createdAt.plus(SESSION_TIME).plus(SPARE_TIME));
+        return isFinished || now().isAfter(this.finishedAt);
+    }
+
+    private LocalDateTime willFinishAt(){
+        return now().plus(SESSION_TIME).plus(SPARE_TIME);
     }
 
     public List<List<Apple>> getApples() {

--- a/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
@@ -3,7 +3,6 @@ package com.snackgame.server.applegame.domain.game;
 import static java.time.LocalDateTime.now;
 
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -29,8 +28,8 @@ public class AppleGame extends BaseEntity {
 
     public static final int DEFAULT_HEIGHT = 10;
     public static final int DEFAULT_WIDTH = 12;
-    private static final Duration SESSION_TIME = Duration.ofSeconds(120);
     private static final Duration SPARE_TIME = Duration.ofSeconds(5);
+    private static final Duration SESSION_TIME = Duration.ofSeconds(120).plus(SPARE_TIME);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,10 +47,9 @@ public class AppleGame extends BaseEntity {
         this.finishedAt = willFinishAt();
     }
 
-    public AppleGame(Board board, Long ownerId, LocalDateTime createdAt, LocalDateTime finishedAt) {
+    public AppleGame(Board board, Long ownerId, LocalDateTime finishedAt) {
         this.board = board;
         this.ownerId = ownerId;
-        this.createdAt = createdAt;
         this.finishedAt = finishedAt;
     }
 
@@ -92,8 +90,8 @@ public class AppleGame extends BaseEntity {
         return isFinished || now().isAfter(this.finishedAt);
     }
 
-    private LocalDateTime willFinishAt(){
-        return now().plus(SESSION_TIME).plus(SPARE_TIME);
+    private LocalDateTime willFinishAt() {
+        return now().plus(SESSION_TIME);
     }
 
     public List<List<Apple>> getApples() {

--- a/src/test/java/com/snackgame/server/applegame/domain/game/AppleGameTest.java
+++ b/src/test/java/com/snackgame/server/applegame/domain/game/AppleGameTest.java
@@ -124,7 +124,7 @@ class AppleGameTest {
 
     @Test
     void 만든지_2분_그리고_여유시간이_지나면_초기화할_수_없다() {
-        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().minusSeconds(125));
+        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().minusSeconds(125), LocalDateTime.now());
 
         assertThatThrownBy(() -> game.restart())
                 .isInstanceOf(GameSessionExpiredException.class)
@@ -133,7 +133,7 @@ class AppleGameTest {
 
     @Test
     void 만든지_2분_그리고_여유시간이_지나면_사과를_제거할_수_없다() {
-        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().minusSeconds(125));
+        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().minusSeconds(125), LocalDateTime.now());
         var range = new Range(
                 new Coordinate(0, 1),
                 new Coordinate(1, 3)

--- a/src/test/java/com/snackgame/server/applegame/domain/game/AppleGameTest.java
+++ b/src/test/java/com/snackgame/server/applegame/domain/game/AppleGameTest.java
@@ -124,7 +124,7 @@ class AppleGameTest {
 
     @Test
     void 만든지_2분_그리고_여유시간이_지나면_초기화할_수_없다() {
-        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().minusSeconds(125), LocalDateTime.now());
+        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now());
 
         assertThatThrownBy(() -> game.restart())
                 .isInstanceOf(GameSessionExpiredException.class)
@@ -133,7 +133,7 @@ class AppleGameTest {
 
     @Test
     void 만든지_2분_그리고_여유시간이_지나면_사과를_제거할_수_없다() {
-        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().minusSeconds(125), LocalDateTime.now());
+        var game = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now());
         var range = new Range(
                 new Coordinate(0, 1),
                 new Coordinate(1, 3)

--- a/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
+++ b/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
@@ -41,24 +41,28 @@ class GameHistoryDaoTest {
 
         this.gameHistoryDao = new GameHistoryDao(jdbcTemplate);
 
-        this.first = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now()));
+        this.first = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
         first.removeApplesIn(new Range(
                 new Coordinate(0, 1),
                 new Coordinate(1, 3)
         ));
-        this.second = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now()));
+        appleGames.save(first);
+        this.second = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
         second.removeApplesIn(new Range(
                 new Coordinate(0, 0),
                 new Coordinate(1, 0)
         ));
-        this.third = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now()));
+        appleGames.save(second);
+        this.third = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
         third.removeApplesIn(new Range(
                 new Coordinate(0, 0),
                 new Coordinate(1, 0)
         ));
-        this.fourth = appleGames.save(new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now()));
-        this.fifth = appleGames.save(
-                new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.of(2024, 2, 5, 12, 13)));
+        appleGames.save(third);
+        this.fourth = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
+        appleGames.save(fourth);
+        this.fifth= new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(3));
+        appleGames.save(fifth);
 
         first.finish();
         second.finish();

--- a/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
+++ b/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
@@ -41,27 +41,27 @@ class GameHistoryDaoTest {
 
         this.gameHistoryDao = new GameHistoryDao(jdbcTemplate);
 
-        this.first = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
+        this.first = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
         first.removeApplesIn(new Range(
                 new Coordinate(0, 1),
                 new Coordinate(1, 3)
         ));
         appleGames.save(first);
-        this.second = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
+        this.second = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
         second.removeApplesIn(new Range(
                 new Coordinate(0, 0),
                 new Coordinate(1, 0)
         ));
         appleGames.save(second);
-        this.third = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
+        this.third = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
         third.removeApplesIn(new Range(
                 new Coordinate(0, 0),
                 new Coordinate(1, 0)
         ));
         appleGames.save(third);
-        this.fourth = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(2));
+        this.fourth = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
         appleGames.save(fourth);
-        this.fifth= new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(),LocalDateTime.now(), LocalDateTime.now().plusDays(3));
+        this.fifth = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(3));
         appleGames.save(fifth);
 
         first.finish();


### PR DESCRIPTION
## 관련 이슈
- resolves: #123 

## 변경 사항
### AS-IS

- 게임의 종료 시간을 지정할 수 없었으며 DB를 update 해야만 게임의 종료를 확정시킬 수 있었다. 

### TO-BE

- 게임의 종료 시간을 생성과 동시에 지정해둔다.

---

- #50 
이 이슈는 `종료 시간`을 지정해두어도 근본적으로 방지할 수가 없어 추후에 다른 방법을 찾아보겠습니다.

### 대신
1. 기존 `isFinished`보다 더 정확한 지표로 사용할 수 있습니다.
2. 테스트의 유연성이 커집니다.

