### PR TITLE
fix: 게임 전적 조회쿼리의 호환성 및 정확성 고려

### DIFF
--- a/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
@@ -38,7 +38,6 @@ public class AppleGame extends BaseEntity {
     @Lob
     private Board board;
     private int score = 0;
-    private boolean isFinished = false;
     private LocalDateTime finishedAt;
 
     public AppleGame(Board board, Long ownerId) {
@@ -77,7 +76,6 @@ public class AppleGame extends BaseEntity {
     public void finish() {
         validateOngoing();
         this.finishedAt = now();
-        this.isFinished = true;
     }
 
     private void validateOngoing() {
@@ -87,7 +85,7 @@ public class AppleGame extends BaseEntity {
     }
 
     public boolean isFinished() {
-        return isFinished || now().isAfter(this.finishedAt);
+        return now().isAfter(this.finishedAt);
     }
 
     private LocalDateTime willFinishAt() {

--- a/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
@@ -52,6 +52,12 @@ public class AppleGame extends BaseEntity {
         this.finishedAt = finishedAt;
     }
 
+    public AppleGame(Board board, Long ownerId, LocalDateTime finishedAt, int score) {
+        this.board = board;
+        this.ownerId = ownerId;
+        this.finishedAt = finishedAt;
+        this.score = score;
+    }
     public static AppleGame ofRandomized(Long ownerId) {
         return new AppleGame(new Board(DEFAULT_HEIGHT, DEFAULT_WIDTH), ownerId);
     }

--- a/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/AppleGame.java
@@ -58,6 +58,7 @@ public class AppleGame extends BaseEntity {
         this.finishedAt = finishedAt;
         this.score = score;
     }
+
     public static AppleGame ofRandomized(Long ownerId) {
         return new AppleGame(new Board(DEFAULT_HEIGHT, DEFAULT_WIDTH), ownerId);
     }
@@ -81,7 +82,7 @@ public class AppleGame extends BaseEntity {
 
     public void finish() {
         validateOngoing();
-        this.finishedAt = now();
+        this.finishedAt = now().minus(SPARE_TIME);
     }
 
     private void validateOngoing() {

--- a/src/main/java/com/snackgame/server/applegame/domain/game/AppleGames.java
+++ b/src/main/java/com/snackgame/server/applegame/domain/game/AppleGames.java
@@ -29,7 +29,7 @@ public interface AppleGames extends JpaRepository<AppleGame, Long> {
 
     @Query(value = "with scores as ("
                    + "select percent_rank() over (order by score desc) as percentile, session_id, score "
-                   + "from apple_game where is_finished = true"
+                   + "from apple_game where finished_at is not null "
                    + ") "
                    + "select percentile "
                    + "    from scores where session_id = :sessionId", nativeQuery = true)

--- a/src/main/java/com/snackgame/server/history/controller/dto/GameHistoryResponse.java
+++ b/src/main/java/com/snackgame/server/history/controller/dto/GameHistoryResponse.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GameHistoryResponse {
 
+    private final long session_id;
+
     private final long memberId;
 
     private final int score;

--- a/src/main/java/com/snackgame/server/history/dao/GameHistoryDao.java
+++ b/src/main/java/com/snackgame/server/history/dao/GameHistoryDao.java
@@ -12,9 +12,10 @@ import com.snackgame.server.history.controller.dto.GameHistoryResponse;
 public class GameHistoryDao {
 
     private static final RowMapper<GameHistoryResponse> GAME_HISTORY_DTO_ROW_MAPPER = ((rs, rowNum) -> new GameHistoryResponse(
+            rs.getLong("session_id"),
             rs.getLong("owner_id"),
             rs.getInt("score"),
-            rs.getDate("updated_at").toLocalDate()
+            rs.getDate("finished_at").toLocalDate()
     ));
     private final JdbcTemplate jdbcTemplate;
 
@@ -23,21 +24,23 @@ public class GameHistoryDao {
     }
 
     public List<GameHistoryResponse> selectByDate(Long memberId) {
-        String sql = "SELECT owner_id, MAX(score) as score, DATE(updated_at) as updated_at " +
-                     "FROM apple_game " +
-                     "WHERE is_finished = true AND owner_id = ? AND DATEDIFF(dd, DATE(now()), DATE(updated_at)) <= 7 " +
-                     "GROUP BY DATE(updated_at) " +
-                     "ORDER BY updated_at DESC";
+        String sql =
+                "SELECT MAX(session_id) as session_id, owner_id, MAX(score) as score, DATE(finished_at) as finished_at "
+                +
+                "FROM apple_game " +
+                "WHERE finished_at is not null AND owner_id = ? AND TIMESTAMPDIFF(DAY ,finished_at, now()) < 7 " +
+                "GROUP BY DATE(finished_at) " +
+                "ORDER BY finished_at DESC";
 
         return jdbcTemplate.query(sql, GAME_HISTORY_DTO_ROW_MAPPER, memberId);
 
     }
 
     public List<GameHistoryResponse> selectBySession(Long memberId, int size) {
-        String sql = "SELECT owner_id, score, updated_at "
+        String sql = "SELECT session_id, owner_id, score, finished_at "
                      + "FROM apple_game "
-                     + "WHERE is_finished = true and owner_id = ? "
-                     + "ORDER BY updated_at desc "
+                     + "WHERE finished_at is not null and owner_id = ? "
+                     + "ORDER BY finished_at desc "
                      + "limit ?";
 
         return jdbcTemplate.query(sql, GAME_HISTORY_DTO_ROW_MAPPER, memberId, size);

--- a/src/main/java/com/snackgame/server/rank/applegame/dao/SessionRankingDao.java
+++ b/src/main/java/com/snackgame/server/rank/applegame/dao/SessionRankingDao.java
@@ -19,7 +19,7 @@ public class SessionRankingDao {
     );
     private static final String RANKING_VIEW = "SELECT rank() over (ORDER BY score DESC) as ranking, session_id " +
                                                "FROM apple_game " +
-                                               "WHERE is_finished = true " +
+                                               "WHERE finished_at is not null " +
                                                "ORDER BY score DESC ";
 
     private final JdbcTemplate jdbcTemplate;
@@ -43,7 +43,7 @@ public class SessionRankingDao {
         String sql = "SELECT ranking, a.session_id "
                      + "FROM apple_game a "
                      + "LEFT JOIN (" + RANKING_VIEW + ") whole_ranks ON a.session_id = whole_ranks.session_id "
-                     + "WHERE owner_id = ? and is_finished = true "
+                     + "WHERE owner_id = ? and finished_at is not null "
                      + "ORDER BY score DESC "
                      + "limit 1";
 

--- a/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
+++ b/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
@@ -1,10 +1,12 @@
 package com.snackgame.server.history.dao;
 
 import static com.snackgame.server.member.fixture.MemberFixture.땡칠;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -13,11 +15,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.snackgame.server.applegame.domain.Coordinate;
-import com.snackgame.server.applegame.domain.Range;
 import com.snackgame.server.applegame.domain.game.AppleGame;
 import com.snackgame.server.applegame.domain.game.AppleGames;
 import com.snackgame.server.applegame.fixture.TestFixture;
+import com.snackgame.server.history.controller.dto.GameHistoryResponse;
 import com.snackgame.server.member.fixture.MemberFixture;
 import com.snackgame.server.support.general.ServiceTest;
 
@@ -31,9 +32,14 @@ class GameHistoryDaoTest {
     private GameHistoryDao gameHistoryDao;
     private AppleGame first;
     private AppleGame second;
+    private AppleGame secondBest;
     private AppleGame third;
     private AppleGame fourth;
     private AppleGame fifth;
+    private AppleGame sixth;
+    private AppleGame sixthBest;
+    private AppleGame seventh;
+    private AppleGame eighth;
 
     @BeforeEach
     void setUp(@Autowired JdbcTemplate jdbcTemplate) {
@@ -41,34 +47,65 @@ class GameHistoryDaoTest {
 
         this.gameHistoryDao = new GameHistoryDao(jdbcTemplate);
 
-        this.first = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
-        first.removeApplesIn(new Range(
-                new Coordinate(0, 1),
-                new Coordinate(1, 3)
-        ));
-        appleGames.save(first);
-        this.second = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
-        second.removeApplesIn(new Range(
-                new Coordinate(0, 0),
-                new Coordinate(1, 0)
-        ));
-        appleGames.save(second);
-        this.third = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
-        third.removeApplesIn(new Range(
-                new Coordinate(0, 0),
-                new Coordinate(1, 0)
-        ));
-        appleGames.save(third);
-        this.fourth = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(2));
-        appleGames.save(fourth);
-        this.fifth = new AppleGame(TestFixture.TWO_BY_FOUR(), 땡칠().getId(), LocalDateTime.now().plusDays(3));
-        appleGames.save(fifth);
+        this.first = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(7),
+                100));
 
-        first.finish();
-        second.finish();
-        third.finish();
-        fourth.finish();
-        fifth.finish();
+        this.second = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(6),
+                200));
+
+        this.secondBest = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(6),
+                250));
+
+        this.third = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(5),
+                300));
+
+        this.fourth = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(4),
+                400));
+
+        this.fifth = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(3),
+                500));
+
+        this.sixth = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(2),
+                600));
+
+        this.sixthBest = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(2),
+                650));
+
+        this.seventh = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now().minusDays(1),
+                700));
+
+        this.eighth = appleGames.save(new AppleGame(
+                TestFixture.TWO_BY_FOUR(),
+                땡칠().getId(),
+                LocalDateTime.now(),
+                800));
 
         appleGames.flush();
 
@@ -77,15 +114,30 @@ class GameHistoryDaoTest {
     @Test
     @Transactional
     void 최근_25게임의_전적을_조회한다() {
-        Assertions.assertThat(gameHistoryDao.selectBySession(땡칠().getId(), 25))
-                .size().isEqualTo(5);
+        assertThat(gameHistoryDao.selectBySession(땡칠().getId(), 25)).size().isEqualTo(10);
     }
 
     @Test
     @Transactional
-    void 최근_7일간의_게임_전적을_조회한다() {
-        Assertions.assertThat(gameHistoryDao.selectByDate(땡칠().getId()))
-                .hasSize(1);
+    void 최근_7일내의_전적들은_7개_이어야한다() {
+        assertThat(gameHistoryDao.selectByDate(땡칠().getId())).hasSize(7);
     }
 
+    @Test
+    @Transactional
+    void 최근_7일내의_전적들은_날짜_내림차순이어야한다() {
+        List<Long> sessionIds = gameHistoryDao.selectByDate(땡칠().getId()).stream().
+                map(GameHistoryResponse::getSession_id).
+                collect(Collectors.toList());
+        assertThat(sessionIds).doesNotContain(first.getSessionId());
+    }
+
+    @Test
+    @Transactional
+    void 최근_7일내의_전적들은_최고점수만_가져야한다() {
+        List<Long> sessionIds = gameHistoryDao.selectByDate(땡칠().getId()).stream().
+                map(GameHistoryResponse::getSession_id).
+                collect(Collectors.toList());
+        assertThat(sessionIds).contains(secondBest.getSessionId(), sixthBest.getSessionId());
+    }
 }


### PR DESCRIPTION
## 관련 PR
- #114 

조금 양이 많을 수 있습니다..

## 변경 사항
### AS-IS

<img width="846" alt="스크린샷 2024-04-04 오후 4 23 37" src="https://github.com/snack-game/server/assets/122357140/aa0105a7-1810-449c-941e-18d104346adc">

1. `DATEDIFF`라는 날짜함수를 h2와 mysql에서 지원하는 방식이 달라 `BadSqlGrammerException`발생하였습니다.

2. 날짜에 대해 `GROUP BY`를 적용하면 같은 날, 동일한 최고점수가 여러개 존재할때 특정할 수 없었습니다.

### TO-BE

1. 호환성을 고려하여 `TIMESTAMPDIFF` 날짜함수를 사용하였습니다.

2. 집계함수 `MAX()`를 사용하여 정확성을 높여 테스트에 적용하였습니다.

---

## 추가 변경 사항

### AS-IS
1. `AppleGame`에서 score를 지정해 줄 수 없어 `removeApple()`을 사용하며 불편함을 겪었고 또한 큰 점수도 테스트에 적용할 수 없었습니다.

### TO-BE
1. `score`를 생성과 동시에 지정할 수 있도록 해두어 테스트의 용이성을 확보하였습니다.
**_현재는 public이지만 추후에 다른 방식을 적용하도록 개선할 예정입니다._**

- #127 
3. 위의 PR에서 존재하던 레거시인 `isFinished`를 제거하고 새로 만든 `finishedAt`을 사용할 수 있도록 대체하였습니다.