### PR TITLE
fix: 개발 페이지를 CORS 허용한다

### DIFF
--- a/src/main/java/com/snackgame/server/config/WebMvcConfig.java
+++ b/src/main/java/com/snackgame/server/config/WebMvcConfig.java
@@ -44,6 +44,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedOriginPatterns(
                         "https://" + HOST_NAME,
                         "https://api." + HOST_NAME,
+                        "https://dev." + HOST_NAME,
+                        "https://dev-api." + HOST_NAME,
                         "https://*snack-game.vercel.app",
                         "http://localhost:[*]"
                 )

--- a/src/main/java/com/snackgame/server/config/WebMvcConfig.java
+++ b/src/main/java/com/snackgame/server/config/WebMvcConfig.java
@@ -43,7 +43,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .exposedHeaders("Location")
                 .allowedOriginPatterns(
                         "https://" + HOST_NAME,
-                        "https://api." + HOST_NAME,
                         "https://dev." + HOST_NAME,
                         "https://dev-api." + HOST_NAME,
                         "https://*snack-game.vercel.app",

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -20,3 +20,7 @@ server:
     session:
       cookie:
         same-site: none
+
+springdoc:
+  api-docs:
+    enabled: false


### PR DESCRIPTION
## 관련 이슈
![image](https://github.com/snack-game/server/assets/39221443/d137f117-a1e4-4b4c-ab75-839d1cdbef69)

## 변경 사항
### AS-IS
- 개발페이지 및 API 문서에 대한 CORS 미설정
- API 문서가 환경에 상관없이 항상 노출되었다

### TO-BE
- CORS 설정 완료
- 운영 환경 API 문서 비활성화