### PR TITLE
test: 테스트이름 수정

### DIFF
--- a/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
+++ b/src/test/java/com/snackgame/server/history/dao/GameHistoryDaoTest.java
@@ -52,7 +52,7 @@ class GameHistoryDaoTest {
     }
 
     @Test
-    void 최근_7일내의_전적들은_날짜_내림차순이어야한다() {
+    void 최근_7일내의_전적들은_최신날짜부터_조회한다() {
         List<Integer> scores = gameHistoryDao.selectByDate(땡칠().getId()).stream().
                 map(GameHistoryResponse::getScore).
                 collect(Collectors.toList());


### PR DESCRIPTION
## 변경 사항
### AS-IS

테스트이름이 테스트의 목적과 차이가 있었습니다.

### TO-BE

테스트이름을 목적에 맞춰 더 명확히 변경하였습니다.

---

추가사항
- 전적 조회 데이터를 최신순으로 주려하다가 '최근 25게임'을 최신순으로 주는 것이 생각보다 복잡하여 프론트와 협의 후 클라이언트에서 처리하기로 합의했습니다.