### PR TITLE
refactor(session): 점수를 직접적으로 수정할 수 없다

### DIFF
--- a/src/main/java/com/snackgame/server/game/session/domain/Session.kt
+++ b/src/main/java/com/snackgame/server/game/session/domain/Session.kt
@@ -21,7 +21,7 @@ abstract class Session(
     private val sessionState = SessionState(timeLimit)
 
     var score: Int = score
-        set(value) {
+        protected set(value) {
             sessionState.validateInProgress()
             if (value <= field) {
                 throw ScoreCanOnlyBeIncreasedException()

--- a/src/main/java/com/snackgame/server/game/snackgame/domain/Snackgame.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/domain/Snackgame.kt
@@ -5,4 +5,10 @@ import java.time.Duration
 import javax.persistence.Entity
 
 @Entity
-class Snackgame(ownerId: Long) : Session(ownerId, Duration.ofMinutes(2))
+class Snackgame(ownerId: Long) : Session(ownerId, Duration.ofMinutes(2)) {
+
+    @Deprecated("스트릭 구현 시 제거 예정")
+    fun setScoreUnsafely(score: Int) {
+        this.score = score
+    }
+}

--- a/src/main/java/com/snackgame/server/game/snackgame/service/SnackgameService.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/service/SnackgameService.kt
@@ -43,7 +43,7 @@ class SnackgameService(
     fun update(memberId: Long, sessionId: Long, request: SnackgameUpdateRequest): SnackgameResponse {
         val game = snackGameRepository.findByIdOrNull(sessionId) ?: throw NoSuchSessionException()
 
-        game.score = request.score
+        game.setScoreUnsafely(request.score)
 
         return SnackgameResponse.of(game)
     }

--- a/src/test/java/com/snackgame/server/game/session/domain/SessionTest.kt
+++ b/src/test/java/com/snackgame/server/game/session/domain/SessionTest.kt
@@ -14,7 +14,11 @@ import org.junit.jupiter.api.Test
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores::class)
 class SessionTest {
 
-    private class SomeSession : Session(0)
+    private class SomeSession : Session(0) {
+        fun updateScoreIndirectly(score: Int) {
+            this.score = score
+        }
+    }
 
 
     @Test
@@ -24,25 +28,25 @@ class SessionTest {
 
     @Test
     fun `점수는 기본 0부터 시작한다`() {
-        val someSession: Session = SomeSession()
+        val someSession = SomeSession()
 
         assertThat(someSession.score).isZero()
     }
 
     @Test
-    fun `점수를 증가시킬 수 있다`() {
-        val someSession: Session = SomeSession()
+    fun `점수를 간접적으로 증가시킬 수 있다`() {
+        val someSession = SomeSession()
 
-        someSession.score += 1
+        someSession.updateScoreIndirectly(someSession.score + 1)
 
         assertThat(someSession.score).isOne()
     }
 
     @Test
-    fun `(아직) 점수를 감소시킬 수는 없다`() {
+    fun `(아직) 점수를 간접적으로라도 감소시킬 수는 없다`() {
         val someExpiredSession = SomeSession()
 
-        assertThatThrownBy { someExpiredSession.score -= 1 }
+        assertThatThrownBy { someExpiredSession.updateScoreIndirectly(someExpiredSession.score - 1) }
             .isInstanceOf(ScoreCanOnlyBeIncreasedException::class.java)
     }
 
@@ -80,7 +84,7 @@ class SessionTest {
     fun `만료된 세션은 변경할 수 없다`() {
         val someExpiredSession = SomeSession().also { it.end() }
 
-        assertThatThrownBy { someExpiredSession.score += 1 }
+        assertThatThrownBy { someExpiredSession.updateScoreIndirectly(1) }
             .isInstanceOf(SessionNotInProgressException::class.java)
     }
 }


### PR DESCRIPTION
## 변경 사항
### AS-IS
문법 상 어디서든 점수 수정이 가능했음

### TO-BE
세션을 상속하는 객체 내에서만 점수 수정이 가능하게 하였음.
현재 스낵게임의 경우는 임시로 점수 수정 메서드를 열어두었음. (`@Deprecated` 표시)