### PR TITLE
feat: 세션 종료 시 백분율 및 게임 메타데이터를 포함한다

### DIFF
--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2.java
@@ -22,6 +22,7 @@ import com.snackgame.server.member.domain.Member;
 
 import lombok.RequiredArgsConstructor;
 
+@Deprecated(forRemoval = true)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v2")

--- a/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Docs.java
+++ b/src/main/java/com/snackgame/server/applegame/controller/AppleGameControllerV2Docs.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Deprecated(forRemoval = true)
 @Tag(name = "🍎 사과 게임")
 public interface AppleGameControllerV2Docs {
 

--- a/src/main/java/com/snackgame/server/game/metadata/Metadata.kt
+++ b/src/main/java/com/snackgame/server/game/metadata/Metadata.kt
@@ -1,0 +1,10 @@
+package com.snackgame.server.game.metadata
+
+enum class Metadata(
+    val id: Long,
+    val localizedName: String
+) {
+
+    APPLE_GAME(1L, "사과게임"),
+    SNACK_GAME(2L, "스낵게임")
+}

--- a/src/main/java/com/snackgame/server/game/metadata/MetadataController.kt
+++ b/src/main/java/com/snackgame/server/game/metadata/MetadataController.kt
@@ -1,0 +1,20 @@
+package com.snackgame.server.game.metadata
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "🎮 게임")
+@RequestMapping("/games")
+@RestController
+class MetadataController {
+
+    @Operation(summary = "게임 메타데이터 나열")
+    @GetMapping
+    fun enumerateMetadata(): List<MetadataResponse> {
+        return Metadata.entries.map { MetadataResponse(it.id, it.localizedName) }
+    }
+}

--- a/src/main/java/com/snackgame/server/game/metadata/MetadataResponse.kt
+++ b/src/main/java/com/snackgame/server/game/metadata/MetadataResponse.kt
@@ -1,0 +1,16 @@
+package com.snackgame.server.game.metadata
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class MetadataResponse(
+    @field:Schema(example = "2")
+    val id: Long,
+    @field:Schema(example = "사과게임")
+    val localizedName: String
+) {
+
+    companion object {
+        fun of(metadata: Metadata): MetadataResponse =
+            MetadataResponse(metadata.id, metadata.localizedName)
+    }
+}

--- a/src/main/java/com/snackgame/server/game/session/domain/Session.kt
+++ b/src/main/java/com/snackgame/server/game/session/domain/Session.kt
@@ -1,6 +1,7 @@
 package com.snackgame.server.game.session.domain
 
 import com.snackgame.server.common.domain.BaseEntity
+import com.snackgame.server.game.metadata.Metadata
 import com.snackgame.server.game.session.exception.ScoreCanOnlyBeIncreasedException
 import java.time.Duration
 import javax.persistence.Embedded
@@ -31,6 +32,8 @@ abstract class Session(
 
     val currentState: SessionStateType
         get() = sessionState.current
+
+    abstract fun getMetadata(): Metadata
 
     fun pause() = sessionState.pause()
     fun resume() = sessionState.resume()

--- a/src/main/java/com/snackgame/server/game/session/event/SessionEndEvent.kt
+++ b/src/main/java/com/snackgame/server/game/session/event/SessionEndEvent.kt
@@ -1,9 +1,10 @@
 package com.snackgame.server.game.session.event
 
+import com.snackgame.server.game.metadata.Metadata
 import com.snackgame.server.game.session.domain.Session
 
 data class SessionEndEvent(
-    val gameId: Long,
+    val metadata: Metadata,
     val ownerId: Long,
     val sessionId: Long,
     val score: Int
@@ -12,7 +13,7 @@ data class SessionEndEvent(
     companion object {
         fun of(session: Session): SessionEndEvent {
             return SessionEndEvent(
-                2, // TODO: Session에 abstractional gameId를 생성
+                session.getMetadata(),
                 session.ownerId,
                 session.sessionId,
                 session.score

--- a/src/main/java/com/snackgame/server/game/session/event/SessionEndEvent.kt
+++ b/src/main/java/com/snackgame/server/game/session/event/SessionEndEvent.kt
@@ -1,0 +1,23 @@
+package com.snackgame.server.game.session.event
+
+import com.snackgame.server.game.session.domain.Session
+
+data class SessionEndEvent(
+    val gameId: Long,
+    val ownerId: Long,
+    val sessionId: Long,
+    val score: Int
+) {
+
+    companion object {
+        fun of(session: Session): SessionEndEvent {
+            return SessionEndEvent(
+                2, // TODO: Session에 abstractional gameId를 생성
+                session.ownerId,
+                session.sessionId,
+                session.score
+            )
+        }
+    }
+}
+

--- a/src/main/java/com/snackgame/server/game/session/service/dto/SessionResponse.kt
+++ b/src/main/java/com/snackgame/server/game/session/service/dto/SessionResponse.kt
@@ -1,17 +1,17 @@
 package com.snackgame.server.game.session.service.dto
 
+import com.snackgame.server.game.metadata.MetadataResponse
 import com.snackgame.server.game.session.domain.Session
-import com.snackgame.server.game.session.domain.SessionStateType
 import java.io.Serializable
-import java.time.LocalDateTime
 
 abstract class SessionResponse(
     session: Session
 ) : Serializable {
 
-    val ownerId: Long = session.ownerId
-    val sessionId: Long = session.sessionId
-    val state: SessionStateType = session.currentState
-    val score: Int = session.score
-    val createdAt: LocalDateTime = session.createdAt
+    val metadata = MetadataResponse.of(session.getMetadata())
+    val ownerId = session.ownerId
+    val sessionId = session.sessionId
+    val state = session.currentState
+    val score = session.score
+    val createdAt = session.createdAt
 }

--- a/src/main/java/com/snackgame/server/game/snackgame/controller/SnackgameController.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/controller/SnackgameController.kt
@@ -2,6 +2,7 @@ package com.snackgame.server.game.snackgame.controller
 
 import com.snackgame.server.auth.token.support.Authenticated
 import com.snackgame.server.game.snackgame.service.SnackgameService
+import com.snackgame.server.game.snackgame.service.dto.SnackgameEndResponse
 import com.snackgame.server.game.snackgame.service.dto.SnackgameResponse
 import com.snackgame.server.game.snackgame.service.dto.SnackgameUpdateRequest
 import com.snackgame.server.member.domain.Member
@@ -34,22 +35,6 @@ class SnackgameController(
         snackgameService.startSessionFor(member.id)
 
     @Operation(
-        summary = "스낵게임 세션 일시정지",
-        description = """
-해당 세션이 일시정지된다.
-
-일시정지된 세션은 별도로 종료하지 않아도 **7일** 후 자동으로 만료된다."""
-    )
-    @PostMapping("/{sessionId}/pause")
-    fun pause(@Authenticated member: Member, @PathVariable sessionId: Long): SnackgameResponse =
-        snackgameService.pause(member.id, sessionId)
-
-    @Operation(summary = "스낵게임 세션 종료", description = "세션을 종료한다")
-    @PostMapping("/{sessionId}/end")
-    fun end(@Authenticated member: Member, @PathVariable sessionId: Long): SnackgameResponse =
-        snackgameService.end(member.id, sessionId)
-
-    @Operation(
         summary = "[임시] 스낵게임 세션 수정",
         description = """
 세션을 수정한다.
@@ -62,4 +47,20 @@ class SnackgameController(
         @PathVariable sessionId: Long,
         @Valid @RequestBody request: SnackgameUpdateRequest,
     ): SnackgameResponse = snackgameService.update(member.id, sessionId, request)
+
+    @Operation(
+        summary = "스낵게임 세션 일시정지",
+        description = """
+해당 세션이 일시정지된다.
+
+일시정지된 세션은 별도로 종료하지 않아도 **7일** 후 자동으로 만료된다."""
+    )
+    @PostMapping("/{sessionId}/pause")
+    fun pause(@Authenticated member: Member, @PathVariable sessionId: Long): SnackgameResponse =
+        snackgameService.pause(member.id, sessionId)
+
+    @Operation(summary = "스낵게임 세션 종료", description = "세션을 종료한다")
+    @PostMapping("/{sessionId}/end")
+    fun end(@Authenticated member: Member, @PathVariable sessionId: Long): SnackgameEndResponse =
+        snackgameService.end(member.id, sessionId)
 }

--- a/src/main/java/com/snackgame/server/game/snackgame/controller/SnackgameController.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/controller/SnackgameController.kt
@@ -31,7 +31,7 @@ class SnackgameController(
     )
     @PostMapping
     fun startSessionFor(@Authenticated member: Member): SnackgameResponse =
-        snackgameService.start(member.id)
+        snackgameService.startSessionFor(member.id)
 
     @Operation(
         summary = "스낵게임 세션 일시정지",

--- a/src/main/java/com/snackgame/server/game/snackgame/domain/Snackgame.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/domain/Snackgame.kt
@@ -1,5 +1,7 @@
 package com.snackgame.server.game.snackgame.domain
 
+import com.snackgame.server.game.metadata.Metadata
+import com.snackgame.server.game.metadata.Metadata.SNACK_GAME
 import com.snackgame.server.game.session.domain.Session
 import java.time.Duration
 import javax.persistence.Entity
@@ -11,4 +13,6 @@ class Snackgame(ownerId: Long) : Session(ownerId, Duration.ofMinutes(2)) {
     fun setScoreUnsafely(score: Int) {
         this.score = score
     }
+
+    override fun getMetadata(): Metadata = SNACK_GAME
 }

--- a/src/main/java/com/snackgame/server/game/snackgame/domain/SnackgameRepository.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/domain/SnackgameRepository.kt
@@ -1,8 +1,20 @@
 package com.snackgame.server.game.snackgame.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface SnackgameRepository : JpaRepository<Snackgame, Long> {
+
+    @Query(
+        value = """
+            with scores as (
+                select percent_rank() over (order by score desc) as percentile, session_id, score 
+                from apple_game where TIMESTAMPDIFF(SECOND, now(), finished_at) <=0
+            )
+            select percentile from scores where session_id = :sessionId""",
+        nativeQuery = true
+    )
+    fun findPercentileOf(sessionId: Long): Double?
 }

--- a/src/main/java/com/snackgame/server/game/snackgame/service/SnackgameService.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/service/SnackgameService.kt
@@ -15,7 +15,7 @@ class SnackgameService(
 ) {
 
     @Transactional
-    fun start(memberId: Long): SnackgameResponse {
+    fun startSessionFor(memberId: Long): SnackgameResponse {
         val game = snackGameRepository.save(Snackgame(memberId))
 
         return SnackgameResponse.of(game)

--- a/src/main/java/com/snackgame/server/game/snackgame/service/SnackgameService.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/service/SnackgameService.kt
@@ -1,17 +1,24 @@
 package com.snackgame.server.game.snackgame.service
 
+import com.snackgame.server.applegame.domain.game.Percentile
+import com.snackgame.server.game.session.event.SessionEndEvent
 import com.snackgame.server.game.session.exception.NoSuchSessionException
 import com.snackgame.server.game.snackgame.domain.Snackgame
 import com.snackgame.server.game.snackgame.domain.SnackgameRepository
+import com.snackgame.server.game.snackgame.service.dto.SnackgameEndResponse
 import com.snackgame.server.game.snackgame.service.dto.SnackgameResponse
 import com.snackgame.server.game.snackgame.service.dto.SnackgameUpdateRequest
+import com.snackgame.server.member.domain.MemberRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SnackgameService(
-    private val snackGameRepository: SnackgameRepository
+    private val snackGameRepository: SnackgameRepository,
+    private val memberRepository: MemberRepository,
+    private val eventPublisher: ApplicationEventPublisher
 ) {
 
     @Transactional
@@ -22,8 +29,17 @@ class SnackgameService(
     }
 
     @Transactional
+    fun update(memberId: Long, sessionId: Long, request: SnackgameUpdateRequest): SnackgameResponse {
+        val game = snackGameRepository.getBy(sessionId)
+
+        game.setScoreUnsafely(request.score)
+
+        return SnackgameResponse.of(game)
+    }
+
+    @Transactional
     fun pause(memberId: Long, sessionId: Long): SnackgameResponse {
-        val game = snackGameRepository.findByIdOrNull(sessionId) ?: throw NoSuchSessionException()
+        val game = snackGameRepository.getBy(sessionId)
 
         game.pause()
 
@@ -31,20 +47,26 @@ class SnackgameService(
     }
 
     @Transactional
-    fun end(memberId: Long, sessionId: Long): SnackgameResponse {
-        val game = snackGameRepository.findByIdOrNull(sessionId) ?: throw NoSuchSessionException()
+    fun end(memberId: Long, sessionId: Long): SnackgameEndResponse {
+        val game = snackGameRepository.getBy(sessionId)
 
         game.end()
 
-        return SnackgameResponse.of(game)
+        eventPublisher.publishEvent(SessionEndEvent.of(game))
+        // TODO: 모듈화 + 이벤트 기반으로 동작하도록 분리. 게임은 게임에만 집중하도록.
+        val member = memberRepository.getById(memberId)
+        member.status.addExp(game.score.toDouble())
+
+        return SnackgameEndResponse.of(game, snackGameRepository.ratePercentileOf(sessionId))
     }
+}
 
-    @Transactional
-    fun update(memberId: Long, sessionId: Long, request: SnackgameUpdateRequest): SnackgameResponse {
-        val game = snackGameRepository.findByIdOrNull(sessionId) ?: throw NoSuchSessionException()
+private fun SnackgameRepository.getBy(sessionId: Long): Snackgame =
+    findByIdOrNull(sessionId) ?: throw NoSuchSessionException()
 
-        game.setScoreUnsafely(request.score)
-
-        return SnackgameResponse.of(game)
+private fun SnackgameRepository.ratePercentileOf(sessionId: Long): Percentile {
+    with(findPercentileOf(sessionId)) {
+        this ?: throw NoSuchSessionException()
+        return Percentile(this)
     }
 }

--- a/src/main/java/com/snackgame/server/game/snackgame/service/dto/SnackgameEndResponse.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/service/dto/SnackgameEndResponse.kt
@@ -1,0 +1,23 @@
+package com.snackgame.server.game.snackgame.service.dto
+
+import com.snackgame.server.applegame.domain.game.Percentile
+import com.snackgame.server.game.session.domain.Session
+import com.snackgame.server.game.session.service.dto.SessionResponse
+import com.snackgame.server.game.snackgame.domain.Snackgame
+import io.swagger.v3.oas.annotations.media.Schema
+
+class SnackgameEndResponse(
+    session: Session,
+    @field:Schema(example = "20")
+    val percentile: Int
+) : SessionResponse(session) {
+
+    companion object {
+        fun of(snackgame: Snackgame, percentile: Percentile): SnackgameEndResponse {
+            return SnackgameEndResponse(
+                snackgame,
+                percentile.percentage()
+            )
+        }
+    }
+}

--- a/src/main/java/com/snackgame/server/member/domain/Member.java
+++ b/src/main/java/com/snackgame/server/member/domain/Member.java
@@ -73,6 +73,10 @@ public class Member extends BaseEntity {
         return id;
     }
 
+    public Status getStatus() {
+        return status;
+    }
+
     public String getNameAsString() {
         return name.getString();
     }


### PR DESCRIPTION
## 변경 사항
### AS-IS
게임 종료 시 기존 사과게임에서 보이던 백분율이 없었음.

### TO-BE
- API 문서를 분리하였음. (특히 지원 중단된 API를 별도로 정의했음. 새 스낵게임 API는 `게임` 탭에서 확인가능)
  <img width="706" alt="image" src="https://github.com/snack-game/server/assets/39221443/a8283d63-b0f6-454d-ad69-af5eedcc3d5f">

- 기존 기능을 이식해 게임 종료 시 점수 및 백분율을 알 수 있게 하였음.
- 게임 자체의 메타데이터(id, 게임 이름 등)을 나열하는 API (1-> 사과게임,  2-> 스낵게임)
  - 이를 바탕으로 랭킹 조회 등 다른 API과 연계 가능