### PR TITLE
feat(snackgame): 세션 당 2초의 스페어 시간을 준다

### DIFF
--- a/src/main/java/com/snackgame/server/game/snackgame/domain/Snackgame.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/domain/Snackgame.kt
@@ -6,8 +6,9 @@ import com.snackgame.server.game.session.domain.Session
 import java.time.Duration
 import javax.persistence.Entity
 
+
 @Entity
-class Snackgame(ownerId: Long) : Session(ownerId, Duration.ofMinutes(2)) {
+class Snackgame(ownerId: Long) : Session(ownerId, SESSION_TIME + SPARE_TIME) {
 
     @Deprecated("스트릭 구현 시 제거 예정")
     fun setScoreUnsafely(score: Int) {
@@ -15,4 +16,9 @@ class Snackgame(ownerId: Long) : Session(ownerId, Duration.ofMinutes(2)) {
     }
 
     override fun getMetadata(): Metadata = SNACK_GAME
+
+    companion object {
+        private val SESSION_TIME = Duration.ofMinutes(2)
+        private val SPARE_TIME = Duration.ofSeconds(2)
+    }
 }


### PR DESCRIPTION
## 변경 사항
### AS-IS
세션시간을 120초로 조여두었으나, 클라이언트-서버 간 통신 지연에 의해 약간의 오차가 발생할 수 있습니다.
그래서 종종 검증 오류가 발생할 수 있습니다.

### TO-BE
세션 종료에 2초의 여유시간을 줍니다.
일단 여유롭게 주었는데, 추후 조정 가능하겠습니다.