### PR TITLE
이름 제약사항 수정

### DIFF
--- a/src/main/java/com/snackgame/server/member/domain/Name.java
+++ b/src/main/java/com/snackgame/server/member/domain/Name.java
@@ -33,7 +33,7 @@ public class Name {
     }
 
     private void validateLengthOf(String string) {
-        if (string.length() < 2) {
+        if (string.length() < 2 || string.length() > 16) {
             throw new NameLengthException();
         }
     }

--- a/src/main/java/com/snackgame/server/member/domain/Name.java
+++ b/src/main/java/com/snackgame/server/member/domain/Name.java
@@ -1,7 +1,8 @@
 package com.snackgame.server.member.domain;
 
+import static java.util.regex.Pattern.matches;
+
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Name {
 
-    private static final Pattern NUMBERED_PATTERN = Pattern.compile(".+_\\d+");
+    private static final String NUMBERED_PATTERN = ".+_\\d+";
     @Column(name = "name")
     private String string;
 
@@ -39,7 +40,7 @@ public class Name {
     }
 
     public Name nextAvailable() {
-        if (NUMBERED_PATTERN.matcher(string).matches()) {
+        if (matches(NUMBERED_PATTERN, string)) {
             int underscoreIndex = string.lastIndexOf('_');
             long currentNumber = Long.parseLong(string.substring(underscoreIndex + 1));
             return with(currentNumber + 1);

--- a/src/main/java/com/snackgame/server/member/service/DistinctNaming.java
+++ b/src/main/java/com/snackgame/server/member/service/DistinctNaming.java
@@ -24,9 +24,9 @@ public class DistinctNaming {
     }
 
     public Name ofGuest() {
-        Name name = nameRandomizer.getBy("guest");
+        Name name = nameRandomizer.getWith("guest");
         while (members.existsByName(name)) {
-            name = nameRandomizer.getBy("guest");
+            name = nameRandomizer.getWith("guest");
         }
         return name;
     }

--- a/src/main/java/com/snackgame/server/member/service/NameRandomizer.kt
+++ b/src/main/java/com/snackgame/server/member/service/NameRandomizer.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class NameRandomizer {
-    fun getBy(prefix: String): Name {
+    fun getWith(prefix: String): Name {
         return Name(prefix + "_" + getRandomizedAlphabets(RANDOMIZED_LENGTH))
     }
 

--- a/src/main/java/com/snackgame/server/member/service/NameRandomizer.kt
+++ b/src/main/java/com/snackgame/server/member/service/NameRandomizer.kt
@@ -10,7 +10,7 @@ class NameRandomizer {
     }
 
     companion object {
-        private const val RANDOMIZED_LENGTH = 12
+        private const val RANDOMIZED_LENGTH = 10
         private const val ALPHABET_POOL = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
         private fun getRandomizedAlphabets(length: Int): String {

--- a/src/main/java/com/snackgame/server/member/service/OidcMemberService.kt
+++ b/src/main/java/com/snackgame/server/member/service/OidcMemberService.kt
@@ -39,7 +39,7 @@ open class OidcMemberService(
     private val IdTokenPayload.distinctName: Name
         get() {
             if (this.name.isNullOrBlank()) {
-                return distinctNaming.from(nameRandomizer.getBy(this.provider))
+                return distinctNaming.from(nameRandomizer.getWith(this.provider))
             }
             return distinctNaming.from(Name(this.name))
         }

--- a/src/test/java/com/snackgame/server/member/domain/NameTest.java
+++ b/src/test/java/com/snackgame/server/member/domain/NameTest.java
@@ -29,7 +29,13 @@ class NameTest {
     }
 
     @Test
-    void 이름이_2글자_이상이면_잘_생성된다() {
+    void 이름이_16글자보다_길면_예외를_던진다() {
+        assertThatThrownBy(() -> new Name("123456789abcdfegh"))
+                .isInstanceOf(NameLengthException.class);
+    }
+
+    @Test
+    void 이름이_2글자_이상_16글자_이하_이면_잘_생성된다() {
         assertThatNoException()
                 .isThrownBy(() -> new Name("2자"));
     }

--- a/src/test/java/com/snackgame/server/member/service/NameRandomizerTest.kt
+++ b/src/test/java/com/snackgame/server/member/service/NameRandomizerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 class NameRandomizerTest {
 
     private val nameRandomizer = NameRandomizer()
+    private val randomizedLength = 10
 
     @Test
     fun `이름 앞에 접두사 및 '_' 가 붙는다`() {
@@ -17,9 +18,9 @@ class NameRandomizerTest {
     }
 
     @Test
-    fun `'_' 뒤 알파벳 12자리를 무작위로 생성한다`() {
+    fun `'_' 뒤 알파벳 10자리를 무작위로 생성한다`() {
         val randomized = nameRandomizer.getBy("guest").string
 
-        assertThat(randomized.substringAfter('_')).hasSize(12)
+        assertThat(randomized.substringAfter('_')).hasSize(randomizedLength)
     }
 }

--- a/src/test/java/com/snackgame/server/member/service/NameRandomizerTest.kt
+++ b/src/test/java/com/snackgame/server/member/service/NameRandomizerTest.kt
@@ -12,14 +12,14 @@ class NameRandomizerTest {
 
     @Test
     fun `이름 앞에 접두사 및 '_' 가 붙는다`() {
-        val randomized = nameRandomizer.getBy("guest").string
+        val randomized = nameRandomizer.getWith("guest").string
 
         assertThat(randomized).startsWith("guest_")
     }
 
     @Test
     fun `'_' 뒤 알파벳 10자리를 무작위로 생성한다`() {
-        val randomized = nameRandomizer.getBy("guest").string
+        val randomized = nameRandomizer.getWith("guest").string
 
         assertThat(randomized.substringAfter('_')).hasSize(randomizedLength)
     }


### PR DESCRIPTION
## 관련 이슈


## 주요 변경 사항
### AS-IS

랜덤 이름의 길이가 `_` 뒤로 12글자를 생성하였습니다. 하지만 이 과정에서 소셜로그인 시 이름의 길이가 너무 길어져 랭킹에서 사용자의 레벨이 제대로 렌더링 되지 않는 문제가 발생하였습니다.

### TO-BE

12글자에서 10글자로 줄여 해결하려합니다.


