### PR TITLE
그룹 탈퇴를 할 수 있다.

### DIFF
--- a/src/main/java/com/snackgame/server/member/controller/MemberController.kt
+++ b/src/main/java/com/snackgame/server/member/controller/MemberController.kt
@@ -65,7 +65,7 @@ class MemberController(
     @PutMapping("/members/me/group")
     fun changeGroup(
         @Authenticated member: Member,
-        @Valid @RequestBody groupRequest: GroupRequest
+        @RequestBody groupRequest: GroupRequest
     ): MemberDetailsResponse {
         memberAccountService.changeGroupNameOf(member.id, groupRequest.group)
         return MemberDetailsResponse.of(member)

--- a/src/main/java/com/snackgame/server/member/service/MemberAccountService.kt
+++ b/src/main/java/com/snackgame/server/member/service/MemberAccountService.kt
@@ -64,9 +64,9 @@ class MemberAccountService(
     }
 
     @Transactional
-    fun changeGroupNameOf(memberId: Long, groupName: String) {
+    fun changeGroupNameOf(memberId: Long, groupName: String?) {
         val member = members.getBy(memberId)
-        val group = groupService.createIfNotExists(groupName)
+        val group = groupName?.let { groupService.createIfNotExists(it) }
         member.changeGroupTo(group)
     }
 

--- a/src/main/java/com/snackgame/server/member/service/dto/GroupRequest.kt
+++ b/src/main/java/com/snackgame/server/member/service/dto/GroupRequest.kt
@@ -1,10 +1,8 @@
 package com.snackgame.server.member.service.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import javax.validation.constraints.NotBlank
 
 
 data class GroupRequest @JsonCreator constructor(
-    @field:NotBlank(message = "그룹 이름은 공백일 수 없습니다")
     val group: String
 )

--- a/src/test/java/com/snackgame/server/member/service/MemberAccountServiceTest.kt
+++ b/src/test/java/com/snackgame/server/member/service/MemberAccountServiceTest.kt
@@ -101,6 +101,14 @@ internal class MemberAccountServiceTest {
     }
 
     @Test
+    fun `그룹 이름이 null이면 그룹을 탈퇴한다`() {
+        val member = memberAccountService.createWith(땡칠().getNameAsString(), 땡칠().group!!.name)
+        memberAccountService.changeGroupNameOf(member.id, null)
+
+        assertThat(memberAccountService.getBy(member.id).group).isNull()
+    }
+
+    @Test
     fun `사용자를 id로 찾는다`() {
         val created = memberAccountService.createWith(땡칠().getNameAsString(), 땡칠().group!!.name)
 


### PR DESCRIPTION
## 변경 사항
### AS-IS

`GroupRequest`에서 유효성 검사를 하여  null을 받을 수 없었습니다.

### TO-BE

1. null을 허용하기 위해 검사를 더이상 진행하지 않습니다
2. null일 경우 그룹 탈퇴를 진행합니다.
