### PR TITLE
refactor(snackgame): 게임 검증API의 응답을 통합한다

### DIFF
--- a/src/main/java/com/snackgame/server/game/snackgame/biz/controller/SnackgameBizController.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/biz/controller/SnackgameBizController.kt
@@ -64,13 +64,12 @@ class SnackgameBizController(
         @Authenticated member: Member,
         @PathVariable sessionId: Long,
         @RequestBody streaksRequest: StreaksRequest
-    ): ResponseEntity<SnackgameResponse?> {
+    ): ResponseEntity<SnackgameResponse> {
         val game = snackgameBizService.removeStreaks(member.id, sessionId, streaksRequest)
-        return game.let {
-            ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(it)
-        } ?: ResponseEntity.ok().build()
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(game)
     }
 
     @Operation(

--- a/src/main/java/com/snackgame/server/game/snackgame/biz/service/SnackgameBizService.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/biz/service/SnackgameBizService.kt
@@ -38,15 +38,13 @@ class SnackgameBizService(
     }
 
     @Transactional
-    fun removeStreaks(memberId: Long, sessionId: Long, streaks: StreaksRequest): SnackgameResponse? {
+    fun removeStreaks(memberId: Long, sessionId: Long, streaksRequest: StreaksRequest): SnackgameResponse {
         val game = snackGameBizRepository.getBy(memberId, sessionId)
-        val previous = game.board
 
-        streaks.toStreaks()
+        streaksRequest.toStreaks()
             .forEach { game.remove(it) }
 
         return SnackgameResponse.of(game)
-            .takeIf { game.board != previous }
     }
 
     @Transactional

--- a/src/main/java/com/snackgame/server/game/snackgame/core/controller/SnackgameController.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/controller/SnackgameController.kt
@@ -63,13 +63,11 @@ class SnackgameController(
         @Authenticated member: Member,
         @PathVariable sessionId: Long,
         @RequestBody streaksRequest: StreaksRequest
-    ): ResponseEntity<SnackgameResponse?> {
+    ): ResponseEntity<SnackgameResponse> {
         val game = snackgameService.removeStreaks(member.id, sessionId, streaksRequest)
-        return game.let {
-            ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(it)
-        } ?: ResponseEntity.ok().build()
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(game)
     }
 
     @Operation(

--- a/src/main/java/com/snackgame/server/game/snackgame/core/controller/SnackgameController.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/controller/SnackgameController.kt
@@ -66,7 +66,7 @@ class SnackgameController(
     ): ResponseEntity<SnackgameResponse> {
         val game = snackgameService.removeStreaks(member.id, sessionId, streaksRequest)
         return ResponseEntity
-            .status(HttpStatus.CREATED)
+            .status(HttpStatus.OK)
             .body(game)
     }
 

--- a/src/main/java/com/snackgame/server/game/snackgame/core/service/SnackgameService.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/service/SnackgameService.kt
@@ -38,10 +38,10 @@ class SnackgameService(
     }
 
     @Transactional
-    fun removeStreaks(memberId: Long, sessionId: Long, streaks: StreaksRequest): SnackgameResponse {
+    fun removeStreaks(memberId: Long, sessionId: Long, streaksRequest: StreaksRequest): SnackgameResponse {
         val game = snackGameRepository.getBy(memberId, sessionId)
 
-        streaks.toStreaks()
+        streaksRequest.toStreaks()
             .forEach { game.remove(it) }
 
         return SnackgameResponse.of(game)

--- a/src/main/java/com/snackgame/server/game/snackgame/core/service/SnackgameService.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/service/SnackgameService.kt
@@ -38,15 +38,13 @@ class SnackgameService(
     }
 
     @Transactional
-    fun removeStreaks(memberId: Long, sessionId: Long, streaks: StreaksRequest): SnackgameResponse? {
+    fun removeStreaks(memberId: Long, sessionId: Long, streaks: StreaksRequest): SnackgameResponse {
         val game = snackGameRepository.getBy(memberId, sessionId)
-        val previous = game.board
 
         streaks.toStreaks()
             .forEach { game.remove(it) }
 
         return SnackgameResponse.of(game)
-            .takeIf { game.board != previous }
     }
 
     @Transactional


### PR DESCRIPTION
## 변경 사항
### AS-IS

10/14 회의에서 @nijuy 님의 요청이 있었습니다.
기존에는 검증 API의 응답이 두가지 경우로 분리되어 있었습니다.
1. 일반 스낵을 제거했을 경우 `OK`만 반환하였습니다.
2. 황금 스낵을 제거했을 경우 `Created`와 세션에 대한 정보를 반환하였습니다.

### TO-BE

스낵의 종류와 무관하게 `Created`와 세션에 대한 정보를 담도록 수정하였습니다.