### PR TITLE
feat(messaging): 알림 발송을 위해 기기를 등록한다

### DIFF
--- a/src/main/java/com/snackgame/server/common/exception/Kind.java
+++ b/src/main/java/com/snackgame/server/common/exception/Kind.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 public enum Kind {
 
     INTERNAL_SERVER_ERROR(true, HttpStatus.INTERNAL_SERVER_ERROR),
-    BAD_REQUEST(false, HttpStatus.BAD_REQUEST);
+    BAD_REQUEST(false, HttpStatus.BAD_REQUEST),
+    IGNORE(false, HttpStatus.OK);
 
     private final boolean needsMessageToBeHidden;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/snackgame/server/messaging/notification/controller/NotificationController.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/controller/NotificationController.kt
@@ -1,0 +1,25 @@
+package com.snackgame.server.messaging.notification.controller
+
+import com.snackgame.server.auth.token.support.Authenticated
+import com.snackgame.server.member.domain.Member
+import com.snackgame.server.messaging.notification.service.NotificationService
+import com.snackgame.server.messaging.notification.service.dto.DeviceTokenRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "🔔 알림")
+@RestController
+class NotificationController(private val notificationService: NotificationService) {
+
+    @Operation(summary = "일반 사용자 생성", description = "기기를 등록한다")
+    @PostMapping("/notification/devices")
+    fun registerDevice(
+        @Authenticated member: Member,
+        @RequestBody deviceTokenRequest: DeviceTokenRequest
+    ) {
+        notificationService.registerDeviceFor(member.id, deviceTokenRequest)
+    }
+}

--- a/src/main/java/com/snackgame/server/messaging/notification/controller/NotificationController.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/controller/NotificationController.kt
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class NotificationController(private val notificationService: NotificationService) {
 
-    @Operation(summary = "일반 사용자 생성", description = "기기를 등록한다")
-    @PostMapping("/notification/devices")
+    @Operation(summary = "기기 등록", description = "기기를 등록한다")
+    @PostMapping("/notifications/devices")
     fun registerDevice(
         @Authenticated member: Member,
         @RequestBody deviceTokenRequest: DeviceTokenRequest

--- a/src/main/java/com/snackgame/server/messaging/notification/domain/Device.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/domain/Device.kt
@@ -1,0 +1,14 @@
+package com.snackgame.server.messaging.notification.domain
+
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+
+@Entity
+class Device(
+    val ownerId: Long,
+    val token: String,
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+)

--- a/src/main/java/com/snackgame/server/messaging/notification/domain/Device.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/domain/Device.kt
@@ -4,8 +4,11 @@ import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.Table
+import javax.persistence.UniqueConstraint
 
 @Entity
+@Table(uniqueConstraints = [UniqueConstraint(columnNames = ["ownerId", "token"])])
 class Device(
     val ownerId: Long,
     val token: String,

--- a/src/main/java/com/snackgame/server/messaging/notification/domain/DeviceRepository.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/domain/DeviceRepository.kt
@@ -4,5 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface DeviceRepository : JpaRepository<Device, Long> {
 
+    fun existsByOwnerIdAndToken(ownerId: Long, token: String): Boolean
+
     fun findAllByOwnerId(ownerId: Long): List<Device>
 }

--- a/src/main/java/com/snackgame/server/messaging/notification/domain/DeviceRepository.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/domain/DeviceRepository.kt
@@ -1,0 +1,8 @@
+package com.snackgame.server.messaging.notification.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DeviceRepository : JpaRepository<Device, Long> {
+
+    fun findAllByOwnerId(ownerId: Long): List<Device>
+}

--- a/src/main/java/com/snackgame/server/messaging/notification/exception/DuplicatedDeviceException.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/exception/DuplicatedDeviceException.kt
@@ -1,0 +1,5 @@
+package com.snackgame.server.messaging.notification.exception
+
+import com.snackgame.server.common.exception.Kind
+
+class DuplicatedDeviceException : NotificationException("이미 등록된 기기입니다", Kind.IGNORE)

--- a/src/main/java/com/snackgame/server/messaging/notification/exception/NotificationException.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/exception/NotificationException.kt
@@ -1,0 +1,9 @@
+package com.snackgame.server.messaging.notification.exception
+
+import com.snackgame.server.common.exception.BusinessException
+import com.snackgame.server.common.exception.Kind
+
+abstract class NotificationException(
+    message: String,
+    kind: Kind = Kind.BAD_REQUEST
+) : BusinessException(kind, message)

--- a/src/main/java/com/snackgame/server/messaging/notification/service/NotificationService.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/service/NotificationService.kt
@@ -2,6 +2,7 @@ package com.snackgame.server.messaging.notification.service
 
 import com.snackgame.server.messaging.notification.domain.Device
 import com.snackgame.server.messaging.notification.domain.DeviceRepository
+import com.snackgame.server.messaging.notification.exception.DuplicatedDeviceException
 import com.snackgame.server.messaging.notification.service.dto.DeviceResponse
 import com.snackgame.server.messaging.notification.service.dto.DeviceTokenRequest
 import org.springframework.stereotype.Service
@@ -10,8 +11,12 @@ import org.springframework.stereotype.Service
 class NotificationService(private val deviceRepository: DeviceRepository) {
 
     fun registerDeviceFor(ownerId: Long, deviceToken: DeviceTokenRequest) {
-        Device(ownerId, deviceToken.token)
-            .let { deviceRepository.save(it) }
+        if (!deviceRepository.existsByOwnerIdAndToken(ownerId, deviceToken.token)) {
+            Device(ownerId, deviceToken.token)
+                .let { deviceRepository.save(it) }
+            return
+        }
+        throw DuplicatedDeviceException()
     }
 
     fun getDevicesOf(ownerId: Long): List<DeviceResponse> {

--- a/src/main/java/com/snackgame/server/messaging/notification/service/NotificationService.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/service/NotificationService.kt
@@ -1,0 +1,21 @@
+package com.snackgame.server.messaging.notification.service
+
+import com.snackgame.server.messaging.notification.domain.Device
+import com.snackgame.server.messaging.notification.domain.DeviceRepository
+import com.snackgame.server.messaging.notification.service.dto.DeviceResponse
+import com.snackgame.server.messaging.notification.service.dto.DeviceTokenRequest
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationService(private val deviceRepository: DeviceRepository) {
+
+    fun registerDeviceFor(ownerId: Long, deviceToken: DeviceTokenRequest) {
+        Device(ownerId, deviceToken.token)
+            .let { deviceRepository.save(it) }
+    }
+
+    fun getDevicesOf(ownerId: Long): List<DeviceResponse> {
+        return deviceRepository.findAllByOwnerId(ownerId)
+            .map { DeviceResponse.of(it) }
+    }
+}

--- a/src/main/java/com/snackgame/server/messaging/notification/service/dto/DeviceResponse.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/service/dto/DeviceResponse.kt
@@ -1,0 +1,15 @@
+package com.snackgame.server.messaging.notification.service.dto
+
+import com.snackgame.server.messaging.notification.domain.Device
+
+data class DeviceResponse(
+    val ownerId: Long,
+    val token: String,
+    val id: Long
+) {
+    
+    companion object {
+
+        fun of(device: Device) = DeviceResponse(device.ownerId, device.token, device.id)
+    }
+}

--- a/src/main/java/com/snackgame/server/messaging/notification/service/dto/DeviceTokenRequest.kt
+++ b/src/main/java/com/snackgame/server/messaging/notification/service/dto/DeviceTokenRequest.kt
@@ -1,0 +1,10 @@
+package com.snackgame.server.messaging.notification.service.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
+
+data class DeviceTokenRequest @JsonCreator constructor(
+    @JsonSetter(nulls = Nulls.FAIL)
+    val token: String
+)

--- a/src/test/java/com/snackgame/server/messaging/notification/controller/NotificationControllerTest.kt
+++ b/src/test/java/com/snackgame/server/messaging/notification/controller/NotificationControllerTest.kt
@@ -1,0 +1,31 @@
+@file:Suppress("NonAsciiCharacters")
+
+package com.snackgame.server.messaging.notification.controller
+
+import com.snackgame.server.member.fixture.MemberFixture
+import com.snackgame.server.member.fixture.MemberFixture.땡칠_인증정보
+import com.snackgame.server.messaging.notification.service.dto.DeviceTokenRequest
+import com.snackgame.server.support.restassured.RestAssuredTest
+import com.snackgame.server.support.restassured.RestAssuredUtil
+import io.restassured.http.ContentType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+@RestAssuredTest
+class NotificationControllerTest {
+
+    @BeforeEach
+    fun setUp() {
+        MemberFixture.saveAll()
+    }
+
+    @Test
+    fun `기기를 등록한다`() {
+        RestAssuredUtil.givenAuthentication(땡칠_인증정보())
+            .contentType(ContentType.JSON)
+            .body(DeviceTokenRequest("a_device_token"))
+            .`when`().post("/notification/devices")
+            .then().statusCode(HttpStatus.OK.value())
+    }
+}

--- a/src/test/java/com/snackgame/server/messaging/notification/controller/NotificationControllerTest.kt
+++ b/src/test/java/com/snackgame/server/messaging/notification/controller/NotificationControllerTest.kt
@@ -25,7 +25,7 @@ class NotificationControllerTest {
         RestAssuredUtil.givenAuthentication(땡칠_인증정보())
             .contentType(ContentType.JSON)
             .body(DeviceTokenRequest("a_device_token"))
-            .`when`().post("/notification/devices")
+            .`when`().post("/notifications/devices")
             .then().statusCode(HttpStatus.OK.value())
     }
 }

--- a/src/test/java/com/snackgame/server/messaging/notification/service/NotificationServiceTest.kt
+++ b/src/test/java/com/snackgame/server/messaging/notification/service/NotificationServiceTest.kt
@@ -1,0 +1,28 @@
+@file:Suppress("NonAsciiCharacters")
+
+package com.snackgame.server.messaging.notification.service
+
+import com.snackgame.server.member.fixture.MemberFixture.땡칠
+import com.snackgame.server.messaging.notification.service.dto.DeviceTokenRequest
+import com.snackgame.server.support.general.ServiceTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+@ServiceTest
+class NotificationServiceTest {
+
+    @Autowired
+    private lateinit var notificationService: NotificationService
+
+    @Test
+    fun `기기를 등록한다`() {
+        val deviceToken = "a_device_token"
+        notificationService.registerDeviceFor(땡칠().id, DeviceTokenRequest(deviceToken))
+
+        assertThat(notificationService.getDevicesOf(땡칠().id))
+            .singleElement()
+            .matches { it.ownerId == 땡칠().id }
+            .matches { it.token == deviceToken }
+    }
+}

--- a/src/test/java/com/snackgame/server/messaging/notification/service/NotificationServiceTest.kt
+++ b/src/test/java/com/snackgame/server/messaging/notification/service/NotificationServiceTest.kt
@@ -3,9 +3,11 @@
 package com.snackgame.server.messaging.notification.service
 
 import com.snackgame.server.member.fixture.MemberFixture.땡칠
+import com.snackgame.server.messaging.notification.exception.DuplicatedDeviceException
 import com.snackgame.server.messaging.notification.service.dto.DeviceTokenRequest
 import com.snackgame.server.support.general.ServiceTest
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -24,5 +26,14 @@ class NotificationServiceTest {
             .singleElement()
             .matches { it.ownerId == 땡칠().id }
             .matches { it.token == deviceToken }
+    }
+
+    @Test
+    fun `한 기기는 한 계정당 한 번만 등록할 수 있다`() {
+        val deviceToken = "a_device_token"
+        notificationService.registerDeviceFor(땡칠().id, DeviceTokenRequest(deviceToken))
+
+        assertThatThrownBy { notificationService.registerDeviceFor(땡칠().id, DeviceTokenRequest(deviceToken)) }
+            .isInstanceOf(DuplicatedDeviceException::class.java)
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #174 의 일부입니다

## What for?
### 배경
이 사건은 영국에서 시작되어... (앱 미리보기 업데이트에서 시작했습니다!)
App Store의 경우 앱 미리보기를 업데이트하려면 새 버전 릴리즈가 필요한데요.
쇠뿔도 단김에 빼라고, 새 버전은 사용자에게 도달하기까지 시간이 걸리기 때문에 푸시 메시징도 한 번에 준비하고 있습니다.

### 버려지는 디바이스 토큰
문제는 현재 앱에서 식별되는 디바이스 토큰이 그냥 버려지게 된다는 것입니다.
하지만 이걸 미리 모아두면?
푸시 시스템이 완성되었을 때 바로 활용할 수 있다는 장점이 있습니다.

## 변경 사항
### AS-IS
앱에서 디바이스 토큰이 잘 식별되지만, 그냥 버려지게 됨

### TO-BE
앱에서 발생하는 디바이스 토큰을 미리 수집해 둠
