### PR TITLE
feat(RankHistory): 랭크 전적을 기록 및 조회할 수 있다

### DIFF
--- a/src/main/java/com/snackgame/server/messaging/push/service/dto/NotificationRequest.java
+++ b/src/main/java/com/snackgame/server/messaging/push/service/dto/NotificationRequest.java
@@ -2,13 +2,15 @@ package com.snackgame.server.messaging.push.service.dto;
 
 import com.google.firebase.messaging.Notification;
 
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
 public class NotificationRequest {
 
     public String title;
     public String body;
+
+    public NotificationRequest(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
 
     public Notification toNotification() {
         return Notification.builder()

--- a/src/main/java/com/snackgame/server/rank/controller/RankingController.kt
+++ b/src/main/java/com/snackgame/server/rank/controller/RankingController.kt
@@ -5,6 +5,8 @@ import com.snackgame.server.member.domain.Member
 import com.snackgame.server.rank.controller.dto.RankResponseV2
 import com.snackgame.server.rank.domain.Season
 import com.snackgame.server.rank.domain.SeasonRepository
+import com.snackgame.server.rank.history.RankHistory
+import com.snackgame.server.rank.history.RankHistoryService
 import com.snackgame.server.rank.service.BestScoreRankService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -17,7 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class RankingController(
     private val bestScoreRankService: BestScoreRankService,
-    private val seasonRepository: SeasonRepository
+    private val seasonRepository: SeasonRepository,
+    private val rankHistoryService: RankHistoryService
 ) {
 
     @Operation(summary = "전체 시즌 - 선두 랭크 조회", description = "전체 시즌에서 랭킹을 선두 50등까지 조회한다")
@@ -64,6 +67,13 @@ class RankingController(
     @GetMapping("/seasons")
     fun showAllSeasons(): List<Season> {
         return seasonRepository.findAll()
+    }
+
+    @GetMapping("/rankings/histories")
+    fun showMembersBelow(
+        @Authenticated member: Member
+    ): List<RankHistory> {
+        return rankHistoryService.findMemberBelow(member.id)
     }
 
     enum class Criteria {

--- a/src/main/java/com/snackgame/server/rank/event/BestScoreRenewalEvent.java
+++ b/src/main/java/com/snackgame/server/rank/event/BestScoreRenewalEvent.java
@@ -1,0 +1,34 @@
+package com.snackgame.server.rank.event;
+
+import com.snackgame.server.game.metadata.Metadata;
+import com.snackgame.server.game.session.event.SessionEndEvent;
+
+import lombok.Getter;
+
+@Getter
+public class BestScoreRenewalEvent {
+
+    private final Metadata metadata;
+
+    private final Long ownerId;
+
+    private final Long sessionId;
+
+    private final Long renewedRank;
+
+    public BestScoreRenewalEvent(Metadata metadata, Long ownerId, Long sessionId, Long renewedRank) {
+        this.metadata = metadata;
+        this.ownerId = ownerId;
+        this.sessionId = sessionId;
+        this.renewedRank = renewedRank;
+    }
+
+    public static BestScoreRenewalEvent of(SessionEndEvent sessionEndEvent, Long renewedRank) {
+        return new BestScoreRenewalEvent(
+                sessionEndEvent.getMetadata(),
+                sessionEndEvent.getOwnerId(),
+                sessionEndEvent.getSessionId(),
+                renewedRank
+        );
+    }
+}

--- a/src/main/java/com/snackgame/server/rank/history/RankHistories.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistories.java
@@ -1,0 +1,28 @@
+package com.snackgame.server.rank.history;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RankHistories extends JpaRepository<RankHistory, Long> {
+
+    RankHistory findByOwnerId(Long ownerId);
+
+    @Modifying
+    @Query(value = "update rank_history "
+                   + "set before_rank = before_rank + 1 "
+                   + "where before_rank >= :newRank and owner_id != :ownerId"
+            , nativeQuery = true)
+    void update(Long ownerId, Long newRank);
+
+    @Query(value = "select * "
+                   + "from rank_history "
+                   + "where owner_id != :ownerId "
+                   + "order by before_rank ASC "
+                   + "limit :size"
+            , nativeQuery = true)
+    List<RankHistory> findBelow(Long ownerId, int size);
+
+}

--- a/src/main/java/com/snackgame/server/rank/history/RankHistory.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistory.java
@@ -1,0 +1,40 @@
+package com.snackgame.server.rank.history;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Entity
+@Table(name = "rank_history")
+@Getter
+public class RankHistory {
+
+    private Long ownerId;
+
+    private Long beforeRank;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    public RankHistory(Long ownerId, Long beforeRank, Long id) {
+        this.ownerId = ownerId;
+        this.beforeRank = beforeRank;
+        this.id = id;
+    }
+
+    public RankHistory renewWith(Long ownerId, Long newRank) {
+        return new RankHistory(ownerId, newRank, id);
+    }
+
+    public boolean canRenewBy(Long rank) {
+        return beforeRank > rank;
+    }
+
+}

--- a/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
@@ -7,17 +7,14 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.snackgame.server.rank.event.BestScoreRenewalEvent;
-import com.snackgame.server.rank.provoke.ProvokeService;
 
 @Service
 public class RankHistoryRenewal {
 
     private final RankHistories rankHistories;
-    private final ProvokeService provokeService;
 
-    public RankHistoryRenewal(RankHistories rankHistories, ProvokeService provokeService) {
+    public RankHistoryRenewal(RankHistories rankHistories) {
         this.rankHistories = rankHistories;
-        this.provokeService = provokeService;
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -29,7 +26,6 @@ public class RankHistoryRenewal {
             /// TODO: 1/16/25 save와 update가 필요한게 같은데 어떻게 잘 합쳐볼수없을까
             rankHistories.save(rankHistory.renewWith(event.getOwnerId(), event.getRenewedRank()));
             rankHistories.update(event.getOwnerId(), event.getRenewedRank());
-            provokeService.reserveProvoking(event.getOwnerId(), event.getSessionId());
         }
     }
 

--- a/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
@@ -1,0 +1,36 @@
+package com.snackgame.server.rank.history;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.snackgame.server.rank.event.BestScoreRenewalEvent;
+import com.snackgame.server.rank.provoke.ProvokeService;
+
+@Service
+public class RankHistoryRenewal {
+
+    private final RankHistories rankHistories;
+    private final ProvokeService provokeService;
+
+    public RankHistoryRenewal(RankHistories rankHistories, ProvokeService provokeService) {
+        this.rankHistories = rankHistories;
+        this.provokeService = provokeService;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void renewHistoryWith(BestScoreRenewalEvent event) {
+
+        RankHistory rankHistory = rankHistories.findByOwnerId(event.getOwnerId());
+        if (rankHistory.canRenewBy(event.getRenewedRank())) {
+            /// TODO: 1/16/25 save와 update가 필요한게 같은데 어떻게 잘 합쳐볼수없을까
+            rankHistories.save(rankHistory.renewWith(event.getOwnerId(), event.getRenewedRank()));
+            rankHistories.update(event.getOwnerId(), event.getRenewedRank());
+            provokeService.reserveProvoking(event.getOwnerId(), event.getSessionId());
+        }
+    }
+
+}

--- a/src/main/java/com/snackgame/server/rank/history/RankHistoryService.kt
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistoryService.kt
@@ -1,0 +1,19 @@
+package com.snackgame.server.rank.history
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class RankHistoryService(
+    private val rankHistories: RankHistories
+) {
+
+    @Transactional(readOnly = true)
+    fun findMemberBelow(ownerId: Long): List<RankHistory> {
+        return rankHistories.findBelow(ownerId, MEMBER_SIZE)
+    }
+
+    companion object {
+        private const val MEMBER_SIZE = 5
+    }
+}

--- a/src/test/java/com/snackgame/server/rank/history/RankHistoriesTest.java
+++ b/src/test/java/com/snackgame/server/rank/history/RankHistoriesTest.java
@@ -1,0 +1,47 @@
+package com.snackgame.server.rank.history;
+
+import static com.snackgame.server.rank.history.fixture.RankHistoryFixture.랭크_1등;
+import static com.snackgame.server.rank.history.fixture.RankHistoryFixture.랭크_4등;
+import static com.snackgame.server.rank.history.fixture.RankHistoryFixture.랭크_5등;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.snackgame.server.rank.history.fixture.RankHistoryFixture;
+import com.snackgame.server.support.general.DatabaseCleaningDataJpaTest;
+
+@DatabaseCleaningDataJpaTest
+public class RankHistoriesTest {
+
+    @Autowired
+    RankHistories rankHistories;
+
+    @BeforeEach
+    void setUp() {
+        RankHistoryFixture.saveAll();
+    }
+
+    @DisplayName("랭크전적 조회 시 하위 3명을 조회한다")
+    @Test
+    void belowContainsThree() {
+
+        List<RankHistory> belows = rankHistories.findBelow(랭크_1등().getOwnerId(), 3);
+
+        assertThat(belows.stream().map(RankHistory::getId)).contains(랭크_4등().getOwnerId());
+    }
+
+    @DisplayName("랭크전적 조회 시 하위 4번째는 조회하지 않는다")
+    @Test
+    void belowDoesNotContainsFourth() {
+
+        List<RankHistory> belows = rankHistories.findBelow(랭크_1등().getOwnerId(), 3);
+
+        assertThat(belows.stream().map(RankHistory::getId)).doesNotContain(랭크_5등().getOwnerId());
+    }
+
+}

--- a/src/test/java/com/snackgame/server/rank/history/RankHistoryRenewalTest.java
+++ b/src/test/java/com/snackgame/server/rank/history/RankHistoryRenewalTest.java
@@ -1,0 +1,46 @@
+package com.snackgame.server.rank.history;
+
+import static com.snackgame.server.member.fixture.MemberFixture.땡칠;
+import static com.snackgame.server.member.fixture.MemberFixture.정언;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.snackgame.server.fixture.BestScoreFixture;
+import com.snackgame.server.game.metadata.Metadata;
+import com.snackgame.server.game.session.event.SessionEndEvent;
+import com.snackgame.server.rank.event.BestScoreRenewalEvent;
+import com.snackgame.server.rank.history.fixture.RankHistoryFixture;
+import com.snackgame.server.support.general.ServiceTest;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ServiceTest
+public class RankHistoryRenewalTest {
+
+    @Autowired
+    RankHistories rankHistories;
+    @Autowired
+    RankHistoryRenewal rankHistoryRenewal;
+
+    @BeforeEach
+    void setUp() {
+        RankHistoryFixture.saveAll();
+        BestScoreFixture.saveAll();
+    }
+
+    @Transactional
+    @DisplayName("랭크를 갱신하면 저장하고 다른 사람들의 랭크도 최신화 된다")
+    @Test
+    void record() {
+
+        rankHistoryRenewal.renewHistoryWith(
+                BestScoreRenewalEvent.of(new SessionEndEvent(Metadata.SNACK_GAME, 정언().getId(), 14, 100), 1L));
+
+        assertThat(rankHistories.findByOwnerId(땡칠().getId()).getBeforeRank()).isEqualTo(2L);
+    }
+
+}

--- a/src/test/java/com/snackgame/server/rank/history/RankHistoryTest.java
+++ b/src/test/java/com/snackgame/server/rank/history/RankHistoryTest.java
@@ -1,0 +1,20 @@
+package com.snackgame.server.rank.history;
+
+import static com.snackgame.server.member.fixture.MemberFixture.땡칠;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class RankHistoryTest {
+
+    @DisplayName("순위가 높으면 전적을 갱신할 수 있다")
+    @Test
+    void compareRank() {
+        RankHistory rankHistory = new RankHistory(땡칠().getId(), 10L, 1L);
+
+        assertThat(rankHistory.canRenewBy(5L)).isTrue();
+    }
+
+}

--- a/src/test/java/com/snackgame/server/rank/history/fixture/RankHistoryFixture.java
+++ b/src/test/java/com/snackgame/server/rank/history/fixture/RankHistoryFixture.java
@@ -1,0 +1,47 @@
+package com.snackgame.server.rank.history.fixture;
+
+
+import static com.snackgame.server.member.fixture.MemberFixture.땡칠;
+import static com.snackgame.server.member.fixture.MemberFixture.똥수;
+import static com.snackgame.server.member.fixture.MemberFixture.유진;
+import static com.snackgame.server.member.fixture.MemberFixture.정언;
+import static com.snackgame.server.member.fixture.MemberFixture.정환;
+
+import com.snackgame.server.member.fixture.MemberFixture;
+import com.snackgame.server.rank.history.RankHistory;
+import com.snackgame.server.support.fixture.FixtureSaver;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class RankHistoryFixture {
+
+    public static RankHistory 랭크_1등() {
+        return new RankHistory(땡칠().getId(), 1L, 1L);
+    }
+
+    public static RankHistory 랭크_2등() {
+        return new RankHistory(똥수().getId(), 2L, 2L);
+    }
+
+    public static RankHistory 랭크_3등() {
+        return new RankHistory(정환().getId(), 3L, 3L);
+    }
+
+    public static RankHistory 랭크_4등() {
+        return new RankHistory(유진().getId(), 4L, 4L);
+    }
+
+    public static RankHistory 랭크_5등() {
+        return new RankHistory(정언().getId(), 5L, 5L);
+    }
+
+    public static void saveAll() {
+        MemberFixture.saveAll();
+        FixtureSaver.save(
+                랭크_1등(),
+                랭크_2등(),
+                랭크_3등(),
+                랭크_4등(),
+                랭크_5등()
+        );
+    }
+}


### PR DESCRIPTION
밀려두었던 작업을 한꺼번에 올리느라 양이 꽤 많습니다 미리 죄송합니다 🥲

## 관련 이슈
- resolves: #197 
- resolves: #198 

## 변경 사항
### AS-IS

### TO-BE

1. `RankHistory`를 만들어 랭크 전적을 기록할 수 있습니다.
2. 최고 점수 갱신 시 `RankHistory`도 업데이트 될 수 있도록 하였습니다.
3. 랭크 갱신 시 본인이 제친 사용자 5명을 조회할 수 있습니다

- 추가 고민사항
이벤트 발행에 대한 검증은 테스트 하지 않아도 되나..?
