### PR TITLE
RankHistory 버그 수정

### DIFF
--- a/src/main/java/com/snackgame/server/rank/history/RankHistories.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistories.java
@@ -13,7 +13,8 @@ public interface RankHistories extends JpaRepository<RankHistory, Long> {
 
     @Modifying
     @Query(value = "update rank_history "
-                   + "set current_rank = current_rank + 1 "
+                   + "set before_rank = current_rank, "
+                   + "current_rank = current_rank + 1 "
                    + "where current_rank >= :newRank and owner_id != :ownerId"
             , nativeQuery = true)
     void update(Long ownerId, Long newRank);

--- a/src/main/java/com/snackgame/server/rank/history/RankHistory.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistory.java
@@ -31,8 +31,9 @@ public class RankHistory {
         this.id = id;
     }
 
-    public RankHistory(Long ownerId) {
+    public RankHistory(Long ownerId, Long currentRank) {
         this.ownerId = ownerId;
+        this.currentRank = currentRank;
     }
 
     public RankHistory renewWith(Long ownerId, Long newRank) {

--- a/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
@@ -42,7 +42,7 @@ public class RankHistoryRenewal {
         if (rankHistory != null) {
             return rankHistory;
         }
-        return rankHistories.save(new RankHistory(event.getOwnerId()));
+        return rankHistories.save(new RankHistory(event.getOwnerId(), event.getRenewedRank()));
     }
 
 }

--- a/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
+++ b/src/main/java/com/snackgame/server/rank/history/RankHistoryRenewal.java
@@ -24,13 +24,12 @@ public class RankHistoryRenewal {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void renewHistoryWith(BestScoreRenewalEvent event) {
-
         RankHistory rankHistory = getOrCreateRankHistoryBy(event);
         if (rankHistory.canRenewBy(event.getRenewedRank())) {
-            /// TODO: 1/16/25 save와 update가 필요한게 같은데 어떻게 잘 합쳐볼수없을까
             rankHistories.save(rankHistory.renewWith(event.getOwnerId(), event.getRenewedRank()));
+            updateAndReserve(event);
         }
-        updateAndReserve(event);
+
     }
 
     private void updateAndReserve(BestScoreRenewalEvent event) {


### PR DESCRIPTION
1. RankHistory를 갱신하였을때 currentRank는 업데이트 하였지만 beforeRank는 그대로이던 문제를 해결하였습니다
2. 등수에 변동이 없는데도 도발이 가능하게 되었던 문제를 해결하였습니다
