### PR TITLE
Kapt 버전이 reflect와 호환되도록 버전 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("plugin.jpa") version "1.9.24"
     id("org.springframework.boot") version "2.7.12"
     id("io.spring.dependency-management") version "1.1.0"
-    id("org.jetbrains.kotlin.kapt") version "2.0.21"
+    id("org.jetbrains.kotlin.kapt") version "1.9.24"
     id("io.freefair.lombok") version "8.10"
 }
 


### PR DESCRIPTION
## 변경 사항
### AS-IS

Kotlin-reflect 라이브러리 버전을 찾지 못하는 문제가 있었습니다

### TO-BE

Kapt 버전을 1.9.x로 다운그레이드 하여 해결하였습니다