### PR TITLE
JVM-target 호환성을 위한 버전업

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("io.freefair.lombok") version "8.10"
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## 변경 사항
### AS-IS

빌드 도중
`w: Inconsistent JVM-target compatibility detected for tasks 'compileJava' (11) and 'kaptGenerateStubsKotlin' (17).`
이라는 warning message가 생기는 것을 확인하였습니다.

### TO-BE

이는 버전이 달라서 Gradle 버전업을 하면 에러가 발생할 수 있다는 것을 알려준 것이므로 나중을 위해 미리 호환성을 맞추었습니다.