### PR TITLE
배포시 프로세스가 종료되지 않는 문제 해결

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -121,5 +121,11 @@ jobs:
           PROCESS_ID="$(lsof -i:$BLUE_PORT -t)"
           if [ -n "$PROCESS_ID" ]; then
             sudo kill -15 $PROCESS_ID
-            echo "구동중인 애플리케이션을 종료했습니다. (pid : $PROCESS_ID)\n"
+            sleep 5
+            if ps -p $PROCESS_ID > /dev/null; then
+              echo "프로세스가 아직 살아있음. 강제 종료합니다."
+              sudo kill -9 $PROCESS_ID
+            else
+              echo "구동중인 애플리케이션을 종료했습니다. (pid : $PROCESS_ID)\n"
+            fi
           fi


### PR DESCRIPTION
## 변경 사항
### AS-IS

최근들어 자주 그린 어플리케이션을 띄운후 블루 어플리케이션의 프로세스가 종료되지 않아 이후 배포 시에 포트 충돌이 발생하는 경우가 발생하였습니다.

### TO-BE

시간을 두어 종료되었는지 확인하고 정상종료 되지 않았다면 강제종료를 시키는 단계를 추가하였습니다
