### PR TITLE
배포 시 프로세스가 종료되지 않는 문제 해결

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -122,5 +122,12 @@ jobs:
           PROCESS_ID="$(lsof -i:$BLUE_PORT -t)"
           if [ -n "$PROCESS_ID" ]; then
             sudo kill -15 $PROCESS_ID
-            echo "구동중인 애플리케이션을 종료했습니다. (pid : $PROCESS_ID)\n"
+            sleep 5
+            if ps -p $PROCESS_ID > /dev/null; then
+              echo "프로세스가 아직 살아있음. 강제 종료합니다."
+              sudo kill -9 $PROCESS_ID
+            else
+              echo "구동중인 애플리케이션을 종료했습니다. (pid : $PROCESS_ID)\n"
+            fi
           fi
+


### PR DESCRIPTION
## 변경 사항
### AS-IS

블루 어플리케이션의 종료를 확정 짓지 않고 스크립트가 종료될 경우 다음 배포에 문제가 되었습니다.

### TO-BE

대기하였다가 종료가 되지 않으면 강제종료를 하게 두었습니다.