### PR TITLE
아이템 발급 시간을 비워둔다

### DIFF
--- a/src/main/java/com/snackgame/server/game/snackgame/core/domain/item/Item.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/domain/item/Item.kt
@@ -18,7 +18,7 @@ class Item(
     @Enumerated(EnumType.STRING)
     val itemType: ItemType,
     var count: Int = 0,
-    var lastGrantedAt: LocalDateTime = LocalDateTime.now(),
+    var lastGrantedAt: LocalDateTime? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,

--- a/src/main/java/com/snackgame/server/game/snackgame/core/domain/item/ItemService.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/domain/item/ItemService.kt
@@ -8,8 +8,6 @@ import com.snackgame.server.game.snackgame.core.service.dto.ItemsResponse
 import com.snackgame.server.game.snackgame.exception.ItemNotReadyException
 import com.snackgame.server.game.snackgame.exception.NoItemException
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
-
 import javax.transaction.Transactional
 
 @Service
@@ -34,7 +32,6 @@ class ItemService(
     }
 
 
-
     @Transactional
     fun useItem(ownerId: Long, itemType: ItemType) {
         val found = itemRepository.findItemByOwnerIdAndItemType(ownerId, itemType)
@@ -43,17 +40,6 @@ class ItemService(
         found.useOne()
         itemRepository.save(found)
     }
-    
-    @Transactional
-    fun issueItem(ownerId: Long, itemType: ItemType) : ItemResponse {
-        val found = itemRepository.findItemByOwnerIdAndItemType(ownerId, itemType)
-            .orElse(Item(ownerId = ownerId, itemType = itemType, count = 0, LocalDateTime.now()))
-
-        found.count += 1
-        itemRepository.save(found)
-        return ItemResponse.of(found)
-    }
-
 
     @Transactional
     fun issueItem(ownerId: Long, itemType: ItemType, grantType: GrantType): ItemResponse {
@@ -64,7 +50,7 @@ class ItemService(
         }
 
         val found = itemRepository.findItemByOwnerIdAndItemType(ownerId, itemType)
-            .orElse(Item(ownerId = ownerId, itemType = itemType, count = 0, LocalDateTime.now()))
+            .orElse(Item(ownerId = ownerId, itemType = itemType, count = 0))
 
         itemGrantHistories.save(ItemGrantHistory(ownerId, itemType, grantType))
         found.addOne()

--- a/src/main/java/com/snackgame/server/game/snackgame/core/service/dto/ItemResponse.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/service/dto/ItemResponse.kt
@@ -8,7 +8,7 @@ data class ItemResponse(
     val ownerId: Long,
     val type: ItemType,
     val count: Int,
-    val lastGrantedAt: LocalDateTime,
+    val lastGrantedAt: LocalDateTime? = null,
 ) {
     companion object {
         fun of(item: Item): ItemResponse {


### PR DESCRIPTION
## 변경 사항
### AS-IS

빈 아이템(아이템 개수가 0개)을 생성 시 날짜를 디폴트로 넣어두었더니 조회 후에 발급이 안되는 문제가 발생하였습니다.

### TO-BE

클라이언트와 논의하여 발급 시에만 날짜를 기록하기로 하였습니다.