### PR TITLE
feat: 아이템은 매일 00시 기준 한번 발급받을 수 있다 (#224)

### DIFF
--- a/src/main/java/com/snackgame/server/game/snackgame/core/domain/item/policy/DailyGrantPolicy.kt
+++ b/src/main/java/com/snackgame/server/game/snackgame/core/domain/item/policy/DailyGrantPolicy.kt
@@ -3,7 +3,7 @@ package com.snackgame.server.game.snackgame.core.domain.item.policy
 import com.snackgame.server.game.snackgame.core.domain.item.ItemGrantHistory
 import com.snackgame.server.game.snackgame.core.domain.item.ItemType
 import org.springframework.stereotype.Component
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Component
 class DailyGrantPolicy : ItemGrantPolicy {
@@ -14,7 +14,8 @@ class DailyGrantPolicy : ItemGrantPolicy {
     ): Boolean {
         val latest = histories.filter { it.grantType == GrantType.DAILY }
             .maxByOrNull { it.grantedAt } ?: return true
-        return latest.grantedAt.plusDays(1).isBefore(LocalDateTime.now())
+
+        return latest.grantedAt.toLocalDate().isBefore(LocalDate.now())
     }
 
 }

--- a/src/test/java/com/snackgame/server/game/snackgame/core/service/ItemServiceTest.kt
+++ b/src/test/java/com/snackgame/server/game/snackgame/core/service/ItemServiceTest.kt
@@ -3,22 +3,23 @@
 package com.snackgame.server.game.snackgame.core.service
 
 
-
-import com.snackgame.server.fixture.SeasonFixture
-import com.snackgame.server.game.snackgame.core.domain.item.Item
+import com.snackgame.server.game.snackgame.core.domain.item.ItemGrantHistories
+import com.snackgame.server.game.snackgame.core.domain.item.ItemGrantHistory
 import com.snackgame.server.game.snackgame.core.domain.item.ItemRepository
 import com.snackgame.server.game.snackgame.core.domain.item.ItemService
 import com.snackgame.server.game.snackgame.core.domain.item.ItemType
 import com.snackgame.server.game.snackgame.core.domain.item.policy.GrantType
-
+import com.snackgame.server.game.snackgame.exception.ItemNotReadyException
 import com.snackgame.server.game.snackgame.fixture.ItemFixture
 import com.snackgame.server.member.fixture.MemberFixture.땡칠
 import com.snackgame.server.member.fixture.MemberFixture.정환
 import com.snackgame.server.support.general.ServiceTest
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
 
 @ServiceTest
 class ItemServiceTest {
@@ -28,6 +29,9 @@ class ItemServiceTest {
 
     @Autowired
     private lateinit var itemRepository: ItemRepository
+
+    @Autowired
+    private lateinit var itemGrantHistories: ItemGrantHistories
 
     @BeforeEach
     fun setUp() {
@@ -62,6 +66,19 @@ class ItemServiceTest {
 
         val checked = itemService.checkItemPresence(정환().id)
         assertThat(checked.items.size).isEqualTo(ItemType.entries.size)
+    }
+
+    @Test
+    fun `아이템은 하루에 한번만 발급받을 수 있다`() {
+        itemGrantHistories.save(
+            ItemGrantHistory(
+                땡칠().id, ItemType.BOMB,
+                GrantType.DAILY, LocalDateTime.now()
+            )
+        )
+
+        assertThatThrownBy { itemService.issueItem(땡칠().id, ItemType.BOMB, GrantType.DAILY) }
+            .isInstanceOf(ItemNotReadyException::class.java)
     }
 
 }


### PR DESCRIPTION
## 변경 사항
### AS-IS

아이템 지급 시기가 "이전에 발급 받은 시간으로부터 1일 후" 였습니다.

### TO-BE

사용자마다 달라져 혼란이 생길 수 있고 클라이언트와 맞추기 위해 매일 00시 기준 하루가 지나면 발급받을 수 있도록 수정하였습니다.