### PR TITLE
모니터링 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
     implementation("com.google.firebase:firebase-admin:9.2.0")
     implementation("com.squareup.okhttp3:okhttp:4.2.2")
 
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/scripts/deploy-rolling.sh
+++ b/scripts/deploy-rolling.sh
@@ -97,6 +97,9 @@ cd "$COMPOSE_DIR"
 
 set_drain true
 
+echo "기존 연결 종료 대기..."
+sleep 15
+
 
 echo "[Pull] 새 이미지 받는 중..."
 docker compose pull

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,3 +20,14 @@ server:
     session:
       cookie:
         same-site: none
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus,loggers"
+  endpoint:
+    health:
+      show-details: never
+    prometheus:
+      enabled: true

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -6,6 +6,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+  servlet:
+    session:
+      cookie:
+        same-site: none
+
 security:
   jwt:
     token:
@@ -13,14 +18,26 @@ security:
       access-expiry-days: ${ACCESS_TOKEN_EXPIRY_DAYS}
       refresh-secret-key: ${REFRESH_TOKEN_SECRET_KEY}
       refresh-expiry-days: ${REFRESH_TOKEN_EXPIRY_DAYS}
+
 server:
   port: ${APPLICATION_PORT}
   forward-headers-strategy: native
-  servlet:
-    session:
-      cookie:
-        same-site: none
 
 springdoc:
   api-docs:
     enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
+  endpoint:
+    health:
+      show-details: never
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: snackgame
+      environment: production

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,5 +26,13 @@ springdoc:
     disabled: true
   override-with-generic-response: false
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ""
+  endpoint:
+    health:
+      show-details: never
 server:
   shutdown: graceful


### PR DESCRIPTION
## 관련 이슈


## 변경 사항
### AS-IS

Spring Actuator 및 Prometheus 메트릭 수집 기능이 없었음
Rolling 배포 시 drain 설정 후 즉시 새 이미지를 pull하여, 기존 연결이 완전히 종료되기 전에 배포가 진행되는 문제가 있었음
`application-production.yml`에서 session cookie same-site 설정 위치가 잘못되어 있었음 (server 하위에 위치)

### TO-BE
`spring-boot-starter-actuator` 및 micrometer-registry-prometheus 의존성 추가
`application.yml `(기본): actuator 엔드포인트 기본 비노출 설정
`application-dev.yml`: health, prometheus, loggers 엔드포인트 노출
`application-production.yml`: health, prometheus 엔드포인트 노출, 애플리케이션/환경 태그(snackgame, production) 추가
Rolling 배포 스크립트(deploy-rolling.sh)에서 drain 설정 후 15초 대기하여 기존 연결이 안전하게 종료된 뒤 배포 진행
`application-production.yml`의 session cookie same-site: none 설정을 올바른 위치(spring.servlet.session.cookie)로 이동